### PR TITLE
notebook testing with github actions

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,0 +1,17 @@
+---
+name: Test Jarvis Notebooks
+on: [push, pull_request]
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix-shell --pure --command "py.test --nbval jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb"
+      - run: nix-shell --pure --command "nbqa black --check jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb"
+      - run: nix-shell --pure --command "nbqa pylint jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb"

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable = invalid-name, missing-module-docstring, pointless-statement

--- a/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb
+++ b/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb
@@ -53,16 +53,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Uncomment the following line if you do have [matminer](https://hackingmaterials.lbl.gov/matminer/) installed in your environment"
+    "Uncomment the necessary lines below if your environment is missing any of [matminer](https://hackingmaterials.lbl.gov/matminer/), jarvis-tools or  Scikit-learn."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip install matminer"
+    "# !pip install matminer\n",
+    "# !pip install -U jarvis-tools\n",
+    "# !pip install -U scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import zipfile\n",
+    "\n",
+    "import requests\n",
+    "from matminer.datasets.convenience_loaders import load_jarvis_dft_3d\n",
+    "\n",
+    "# from jarvis.db.figshare import data\n",
+    "from jarvis.core.atoms import Atoms\n",
+    "from sklearn.cluster import KMeans\n",
+    "from sklearn import preprocessing as pp\n",
+    "from sklearn.decomposition import PCA\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -77,9 +102,9 @@
    },
    "outputs": [],
    "source": [
-    "from matminer.datasets.convenience_loaders import load_jarvis_dft_3d\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "dft3d_df = load_jarvis_dft_3d(data_home='.')"
+    "dft3d_df = load_jarvis_dft_3d(data_home=\".\")"
    ]
   },
   {
@@ -116,6 +141,13 @@
    ],
    "source": [
     "print(dft3d_df.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dropna` method drops the rows that contain any NaN (not a number) values."
    ]
   },
   {
@@ -432,12 +464,9 @@
     }
    ],
    "source": [
-    "'''\n",
-    "dropna(): Drop rows that contain any NaN (not a number) values.\n",
-    "'''\n",
     "dft3d_df = dft3d_df.dropna()\n",
     "\n",
-    "#Fetch the first 50 rows\n",
+    "# Fetch the first 50 rows\n",
     "dft3d_50 = dft3d_df.head(50)\n",
     "\n",
     "dft3d_50[:10]"
@@ -453,21 +482,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "gqFLu2zidKEU",
-    "outputId": "da764e75-41a1-41fe-9d7f-e2ef7d9228e1"
-   },
-   "outputs": [],
-   "source": [
-    "# !pip install -U jarvis-tools"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -476,29 +490,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "def read_data():\n",
-    "    import requests\n",
-    "    import json\n",
-    "    import zipfile\n",
-    "    \n",
+    "    \"\"\"Temporary download data function due to\n",
+    "    https://github.com/usnistgov/jarvis/issues/251\n",
+    "    \"\"\"\n",
+    "\n",
     "    json_tag = \"jdft_3d-8-18-2021.json\"\n",
     "    url = \"https://ndownloader.figshare.com/files/29204826\"\n",
     "    tmpfile = \"tmp.zip\"\n",
-    "    \n",
+    "\n",
     "    response = requests.get(url)\n",
     "    with open(tmpfile, \"wb\") as f:\n",
-    "        for d in response.iter_content(1024):\n",
-    "            f.write(d)\n",
+    "        for block in response.iter_content(1024):\n",
+    "            f.write(block)\n",
     "    return json.loads(zipfile.ZipFile(tmpfile).read(json_tag))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -516,16 +530,13 @@
     }
    ],
    "source": [
-    "from jarvis.db.figshare import data\n",
-    "from jarvis.core.atoms import Atoms\n",
-    "\n",
     "dft_3d = read_data()\n",
     "\n",
     "comp_list = []\n",
     "for indx, d in dft3d_50.iterrows():\n",
-    "  entry = next(j for j in dft_3d if j[\"jid\"] == d[\"jid\"])\n",
-    "  comp = Atoms.from_dict(entry['atoms']).composition.reduced_formula\n",
-    "  comp_list.append(comp)\n",
+    "    entry = next(j for j in dft_3d if j[\"jid\"] == d[\"jid\"])\n",
+    "    comp = Atoms.from_dict(entry[\"atoms\"]).composition.reduced_formula\n",
+    "    comp_list.append(comp)\n",
     "\n",
     "print(comp_list)"
    ]
@@ -541,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -585,14 +596,18 @@
        "         2.16400e+01,  1.83388e+01,  8.70000e-03]])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#Form feature vector from the scalar properties in the dataframe\n",
-    "scalar_cols = [col for col in dft3d_50.columns if col not in ['structure', 'structure initial', 'jid', 'mpid', 'composition']]\n",
+    "# Form feature vector from the scalar properties in the dataframe\n",
+    "scalar_cols = [\n",
+    "    col\n",
+    "    for col in dft3d_50.columns\n",
+    "    if col not in [\"structure\", \"structure initial\", \"jid\", \"mpid\", \"composition\"]\n",
+    "]\n",
     "\n",
     "feature_vect = dft3d_50[scalar_cols].to_numpy()\n",
     "\n",
@@ -611,21 +626,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "ZaGVRxi0o6Ko",
-    "outputId": "5ee4bfbe-c74c-4e1f-aa77-e2322ace2a91"
-   },
-   "outputs": [],
-   "source": [
-    "#!pip install -U scikit-learn"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "svLOsMPEW00E"
@@ -635,12 +635,15 @@
     "\n",
     "**Try modifying**\n",
     "\n",
-    "Run the K--means clustering on the un-scaled feature vector ``feature_vect`` instead to see what happens"
+    "Run the K--means clustering on the un-scaled feature vector ``feature_vect`` instead to see what happens\n",
+    "\n",
+    "The following scales the feature vector as a pre-processing step such that features have zero mean and\n",
+    "unit variance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -661,19 +664,12 @@
     }
    ],
    "source": [
-    "from sklearn.cluster import KMeans\n",
-    "from sklearn import preprocessing as pp\n",
-    "\n",
-    "'''\n",
-    "Scale feature vector: pre-processing step such that features have zero mean and \n",
-    "unit variance\n",
-    "''' \n",
     "scaler = pp.StandardScaler().fit(feature_vect)\n",
     "\n",
     "feat_vec_scale = scaler.transform(feature_vect)\n",
     "\n",
-    "print('mean: ', feat_vec_scale.mean(axis=0))\n",
-    "print('std. deviation: ', feat_vec_scale.std(axis=0))"
+    "print(\"mean: \", feat_vec_scale.mean(axis=0))\n",
+    "print(\"std. deviation: \", feat_vec_scale.std(axis=0))"
    ]
   },
   {
@@ -691,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -704,8 +700,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[3 3 2 2 2 2 2 0 2 3 3 3 2 3 2 2 0 2 2 2 2 0 2 2 2 1 2 2 0 4 0 0 0 0 0 0 0\n",
-      " 0 2 2 2 0 0 0 0 2 2 2 2 2]\n"
+      "[3 3 1 1 1 1 1 0 1 3 3 3 0 3 1 1 0 1 1 1 1 0 1 1 1 2 1 1 0 4 0 0 0 0 0 0 0\n",
+      " 0 1 1 1 0 0 0 0 1 1 1 1 1]\n"
      ]
     }
    ],
@@ -713,10 +709,13 @@
     "# NBVAL_IGNORE_OUTPUT\n",
     "# Stochastic output\n",
     "\n",
-    "#Fit K-means model\n",
+    "# Fit K-means model\n",
     "\n",
-    "K = 5; #CHANGE the number of clusters generated\n",
-    "kmeans = KMeans(n_clusters=K).fit(feat_vec_scale) #CHANGE to the unscaled/un-whitened feature_vect to see what happens!\n",
+    "K = 5\n",
+    "# CHANGE the number of clusters generated\n",
+    "kmeans = KMeans(n_clusters=K).fit(\n",
+    "    feat_vec_scale\n",
+    ")  # CHANGE to the unscaled/un-whitened feature_vect to see what happens!\n",
     "lbl = kmeans.labels_\n",
     "centers = kmeans.cluster_centers_\n",
     "y_kmeans = kmeans.predict(feat_vec_scale)\n",
@@ -739,24 +738,24 @@
      "output_type": "stream",
      "text": [
       "Generated Compound Cluster #1\n",
-      "['AlHO2' 'ScHO2' 'NdIO' 'BeF2' 'CO2' 'CaCl2' 'SrClF' 'SrBrF' 'SrCl2'\n",
-      " 'CaCl2' 'CaClF' 'NaHF2' 'AsF3' 'KSc2F7' 'CClF3' 'K2MgF4']\n",
+      "['AlHO2' 'ScBrO' 'ScHO2' 'NdIO' 'BeF2' 'CO2' 'CaCl2' 'SrClF' 'SrBrF'\n",
+      " 'SrCl2' 'CaCl2' 'CaClF' 'NaHF2' 'AsF3' 'KSc2F7' 'CClF3' 'K2MgF4']\n",
       "mean feature values of the cluster:\n",
-      "[{'epsilon_x opt': -0.5132547831730443}, {'epsilon_y opt': -0.45557719589338685}, {'epsilon_z opt': -0.4141502475546219}, {'e_form': -0.9467337547733757}, {'shear modulus': -0.05522530984902496}, {'bulk modulus': -0.06018701692796912}, {'gap tbmbj': 1.109461430619794}, {'epsilon_x tbmbj': -0.4511823847700216}, {'epsilon_y tbmbj': -0.36064511170660224}, {'epsilon_z tbmbj': -0.30576088850794414}, {'gap opt': 1.134001290054098}]\n",
+      "[{'epsilon_x opt': -0.49856046466816817}, {'epsilon_y opt': -0.44987579963068974}, {'epsilon_z opt': -0.40449841660578467}, {'e_form': -0.9600209024705456}, {'shear modulus': -0.0472778785120525}, {'bulk modulus': -0.06203775122462261}, {'gap tbmbj': 1.028887385213975}, {'epsilon_x tbmbj': -0.4384430194885642}, {'epsilon_y tbmbj': -0.35688308637197885}, {'epsilon_z tbmbj': -0.29937843629234284}, {'gap opt': 1.0672560059995477}]\n",
       "\n",
       "\n",
       "Generated Compound Cluster #2\n",
-      "['CoF2']\n",
+      "['MoO3' 'AgI' 'ZrBrN' 'InBr3' 'YI3' 'BiOF' 'VOF3' 'ZnCl2' 'ZrMo2O8'\n",
+      " 'BaCaI4' 'CaPbI4' 'YBr3' 'Li2WS4' 'SnO2' 'SnO2' 'GaS' 'RbPS3' 'Bi2SO2'\n",
+      " 'BrF5' 'IF7' 'LiMgP' 'H4BrN' 'NaHS' 'SrAl2Te4' 'AgAsF6']\n",
       "mean feature values of the cluster:\n",
-      "[{'epsilon_x opt': 5.118080483232208}, {'epsilon_y opt': 5.176294061860992}, {'epsilon_z opt': 5.821624635010576}, {'e_form': 0.24850991676223486}, {'shear modulus': 0.6453762819050016}, {'bulk modulus': 2.169974828558438}, {'gap tbmbj': -1.4111669293016793}, {'epsilon_x tbmbj': 4.325172905340975}, {'epsilon_y tbmbj': 5.546947827501139}, {'epsilon_z tbmbj': 6.202183200667313}, {'gap opt': -1.3897437533069272}]\n",
+      "[{'epsilon_x opt': -0.21682222679516291}, {'epsilon_y opt': -0.23587457661443534}, {'epsilon_z opt': -0.16805750265177455}, {'e_form': 0.5233023387250574}, {'shear modulus': -0.2717191062119349}, {'bulk modulus': -0.30732137643418195}, {'gap tbmbj': -0.3734596970308861}, {'epsilon_x tbmbj': -0.2512046137285392}, {'epsilon_y tbmbj': -0.2548553906640444}, {'epsilon_z tbmbj': -0.19708268826991868}, {'gap opt': -0.4074735795047337}]\n",
       "\n",
       "\n",
       "Generated Compound Cluster #3\n",
-      "['MoO3' 'AgI' 'ZrBrN' 'InBr3' 'YI3' 'BiOF' 'ScBrO' 'VOF3' 'ZnCl2'\n",
-      " 'ZrMo2O8' 'BaCaI4' 'CaPbI4' 'YBr3' 'Li2WS4' 'SnO2' 'SnO2' 'GaS' 'RbPS3'\n",
-      " 'Bi2SO2' 'BrF5' 'IF7' 'LiMgP' 'H4BrN' 'NaHS' 'SrAl2Te4' 'AgAsF6']\n",
+      "['CoF2']\n",
       "mean feature values of the cluster:\n",
-      "[{'epsilon_x opt': -0.21861565532573934}, {'epsilon_y opt': -0.24059684133801615}, {'epsilon_z opt': -0.17121179568149048}, {'e_form': 0.4580747385577374}, {'shear modulus': -0.2581960243238025}, {'bulk modulus': -0.2990263042625242}, {'gap tbmbj': -0.36910729873274156}, {'epsilon_x tbmbj': -0.2505664814691818}, {'epsilon_y tbmbj': -0.2564644402930429}, {'epsilon_z tbmbj': -0.19708947721502657}, {'gap opt': -0.3918272317881384}]\n",
+      "[{'epsilon_x opt': 5.118080483232208}, {'epsilon_y opt': 5.176294061860992}, {'epsilon_z opt': 5.821624635010576}, {'e_form': 0.24850991676223486}, {'shear modulus': 0.6453762819050016}, {'bulk modulus': 2.169974828558438}, {'gap tbmbj': -1.4111669293016793}, {'epsilon_x tbmbj': 4.325172905340975}, {'epsilon_y tbmbj': 5.546947827501139}, {'epsilon_z tbmbj': 6.202183200667313}, {'gap opt': -1.3897437533069272}]\n",
       "\n",
       "\n",
       "Generated Compound Cluster #4\n",
@@ -778,17 +777,18 @@
     "# NBVAL_IGNORE_OUTPUT\n",
     "# Stochastic ouput\n",
     "\n",
-    "#Print contents of each cluster\n",
-    "import numpy as np\n",
+    "# Print contents of each cluster\n",
     "\n",
-    "for k in range(K): #For each generated cluster\n",
-    "    pos= [n for (n,m) in enumerate(lbl) if m==k] #Get the indices in the labels vector which point ot that cluster\n",
+    "for k in range(K):  # For each generated cluster\n",
+    "    pos = [\n",
+    "        n for (n, m) in enumerate(lbl) if m == k\n",
+    "    ]  # Get the indices in the labels vector which point ot that cluster\n",
     "    compGrp = np.array(comp_list)[pos]\n",
-    "    print('Generated Compound Cluster #{}'.format(k+1))\n",
+    "    print(f\"Generated Compound Cluster #{k + 1}\")\n",
     "    print(compGrp)\n",
-    "    print('mean feature values of the cluster:')\n",
-    "    print([{f:m} for f,m in zip(scalar_cols, centers[k])])\n",
-    "    print('\\n')"
+    "    print(\"mean feature values of the cluster:\")\n",
+    "    print([{f: m} for f, m in zip(scalar_cols, centers[k])])\n",
+    "    print(\"\\n\")"
    ]
   },
   {
@@ -806,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -825,7 +825,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxEElEQVR4nO3dd5hU5dnH8e89bSu9V+lNigIiFtSI3ajEWKJGE40xMajvaxJ9NYk9do0mpmkSg9g1tmAsQVFQVKoo0uvSYSnby7T7/WNmYZed3Z2FmTmzzP25rrlgz5w957eLnnvOc54iqooxxpjM43I6gDHGGGdYATDGmAxlBcAYYzKUFQBjjMlQVgCMMSZDeZwO0BwdO3bUPn36OB3DGGNalAULFuxU1U77b29RBaBPnz7Mnz/f6RjGGNOiiEhBrO3WBGSMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgKQAhrchPrnoeE9Tkcxxpi9WlQvoJZGw+Vo0fXgnwfiA/WjuZcgrW5FRJyOZ4zJcHYHkERa8hvwzwWqQUsjf1a+jFa85HQ0Y4yxApAsGq6AqumAf783KqHin45kMsaY2qwAJItWNvxeuDh1OYwxpgFWAJLF1R5cHWK9Ab5jUh7HGGP2ZwUgSUQEaXMPkM2+X7MXJB9p9XMHkxljTIT1AkoiyToBOryElv8DggXgG4PkXYm4uzodzRhjrAAkm3iHIW0fdTqGMcbUY01AxhiToRwtACLiFZFHRWS1iGwUkXZO5jHGmEzidBPQn4GtwECHcxhjTMZxrACISFfgWGCEqqpTOYwxJlM52QQ0HFBghoisEJHnRSRv/51E5BoRmS8i8wsLC1Of0hhjDlFOFoDOwErgdGAYsB24Y/+dVPUpVR2rqmM7daq3pKUxxpgD5GQB2AOUq2q1qoaAN4GhDuYxxpiM4mQBmA2cICJ9ol+fCcxxLo4xxmQWxx4Cq2qJiPwIeEtEvMDnwM+cymOMMZnG0W6gqvoBMMrJDMYYk6lsJLAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToawAGGNMhrICYIwxGcoKgDHGZCgrAMYYk6GsABhjTIayAmCMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToawAGGNMhrICYIwxGcoKgDHGZCgrAMYYk6GsABhjTIayAmCMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToRosACLSQUR+JyLPi8hVIiK13luamnjGGGOSpbE7gKlAIfAicBrwvojkR9+TBr/LGGNMi+Bp5L2+qnp29O9vi8jPiBSBMwFNfjRjjDHJ1FgB8IpItqpWAajqn0WkDHgbyE5JOmOMMUnTWBPQX4Fja29Q1anAc1gTkDHGtHgN3gGo6qMNbH8KeCppiYwxxqSEdQM1xpgMlRYFQERuEpFvnM5hjDGZxPECICLHAZc6ncMYYzJNkwVARJ6MsS0hzwBEpCPwGPDTRBzPGGNM/OK5A5hQ+wsR8QFnHOyJoyOLnwFuBrY3st81IjJfROYXFhYe7GmNMcZENTYVxLUishjoKyJfR1+LgQ3AtASc+0bgM1X9uLGdVPUpVR2rqmM7deqUgNMaY4yBxgeCvQC8C9wH3Fpre5GqFifg3H2B00TkcsAL9BSRT1R1QhPfZ4wxJgEaGwdQDBQDl4pIV6AbkQFgHUQEVV14MCdW1etr/i4ifYC37eJvjDGp09gdAAAi8jBwCbAWCEU3K3ByEnMZY4xJsiYLAHA+0F9Vq5MVQlXXA8OTdXxjjDH1xdMLaCOQlewgxhhjUiueOwCAt6I9gPZS1RuSkMcYY0yKxFMA/pn0FMYYY1KuyQKgqs+IyECgn6q+H+0RZIwxpoWLZyqIXwLPA3+LbuoCvJLMUMYYY5IvnofAVwPHAeUAqvoV0DOZoYwxxiRfPAWgUlUDNV+ISB6QtC6hxhhjUiOeAvC6iDwC5IjIhUSmh3ghubGMMcYkWzwPge8Rke8CbYjMAvpnVX0p6cmMMcYkVVzjAFT1NeC1JGcxxhiTQvH0ArpARJaLSLGIlIhIqYiUpCKcMcaY5InnDuAR4BxgiaqGk5zHGGNMisTzEHgndvE3xphDTjx3AKuAh0Vkdu2Nqvp6ciIZY4xJhXgKQBXQnkgzUA0FrAAYY0wLFk830CtTEcQYY0xqxdMLqKuIvCoi26Ovf4lI91SEM8YYkzzxPASeArwFdI++3ohuM8YY04LFUwB6q+pzqhqKvp4HeiU7mDHGmOSKpwBsEpFLRcQVfV0KbE52MGOMMckVTwG4ErgA2B59XRDdZowxpgWLpxfQZuD8FGQxxhiTQvH0AhomItNEZJOIrBKRP4tI+1SEM8YYkzzxDAR7EbgXuAjwAVcBU4FvJzGXMcZkvK07ivn39K/ZubuUo47oy7fGD8LrdSfs+PFOB12zBnAl8JiI/CRhCYwxxtQz58t1/PrhtwiGwgSDYT7+YhUvvDmXv9x7CTnZvoScI56HwAtE5DQRaR999QB2ikg7awoyxpjEC4XC3P37d6iqDhIMRubhrKwKsGHLHl57d1HCzhPPHcC3oq/9LSQyJ1C/hKUxxhjD2g07CQSC9bb7/UE+/HQZ3//OuIScJ55eQH0TciZjjDFxyfJ5CKvGfi/Lm7DzNFkARCQHOA/oBkjNdlX9XcJSGGOM2atX93Z06diaDVt2U7sOZGd5Of+MIxJ2nnieAbwLnAu0BVrVepkmVJZXMX3qTF6473UWfvA14bCtqWOMaZqIcP8tk2jfNo/cHB/ZWV58Xg+nHD+EUycMTdh54nkG0EVVT0rYGTNEwdKN3HjC7QT8QfwV1fhys+g3ojcPfXA7WTlZTsczxqS53t3b89qTP2H+1wXs3lPOyKE96NmtXULPEc8dwFwRGZ3Qs2aAey95nLI9ZVSVVREOK1VlVaxetI5//W6a09GMMS2Ex+1i/JF9Oevk4Qm/+EOc3UCBz0SkJPoqFZGShCc5hOzcsptNq7ay/zMcf2WA96d87EgmY4zZXzxNQNcDI4DVqg08ls4wFaWVzHv3S/zVAcaefgTtOrepu4P9mowxLUA8BWAnsM4u/hHz3l/E3Rc8grhcqCrhYIhrHr6c8yafuXefjj060KN/VwqWbqxTC3zZXk674sQ6x6ssq2TqXa/y4fOfgCrfuuR4rrjzIvJa56bqRzLGZChp6rouItOAUmB+7e1OdAMdO3aszp8/v+kdk6S8pILvdb+GqorqOtt9OT7+PO8BDhu2b52cdd9s4Ocn3k7QH6SqopqcvGwOO7wXj8y4Y+9D4HA4zORxt1CwZBOB6gAA3iwPPQZ2569fPoTbnbg5P4wxmUtEFqjq2P23x3MHUHPFzfiun19MW4C4pN72oD/I9GdncfX9l+3d1nd4b14o+AszX/2CnZt2MXjcAMacOhKXa99jlwXTv2bzyq17L/4Ageog2wt2MPedLznmnHr/XsYYkzDxjAS+C0BE8qNflyXixCKSDbwN9AVCwBRVvS8Rx04Wf5WfWHdMGg5TVV5Vb3tOfg5nXBlrFo2IVQvWUl3pr7e9srSK1QvXWQEwxiRVPOsBDBGRecBi4BsRmSciiRqJ8KCq9gdGAReLyBEJOm5SjD39CMKh+oO5snKzmHD++GYfr2vfzmTl1J/VLzs/m659Ox9QRmOMiVc83UD/DvxcVfuqah/gxui2g6KqVao6Pfr3SmA10OVgj5tMnXp24Io7LyIrx4cr2hSUnZfFcd85mpEnDmv28Y7/zjiy87L2HgtAXEJWjo8JFzS/oBhjTHPE8xB4maoObWrbQYUQ6UJkdtHDVbWoof2cfghcY9XCtUyfOhN/lZ8TLjiGIyeOQKT+s4F4bF27nQd/8AQr5q4GYODoftw89Xp6DuyWyMjGmAzW0EPgeArAq8Ai4LnopsuAMar63QQFywKmA0+r6pQY718DXAPQu3fvMQUFBYk4bdopLy4HIK9NnsNJjDGHmoYKQDxNQFcDHYA3gNeBjsCPEhTKB7wGvBvr4g+gqk+p6lhVHdupU6dEnDYmVWXt1wUs/WIlAX+g6W9IsLw2eXbxN8akVIO9gKLNMj1VdQHw81rbjySyNvBBEZFcIkVlhqo+eLDHOxgFyzZx2zkPsGd7ES63CxHh5inXcex5RzkZyxhjkqqxO4AHgJExto8Efp+Ac48DTgKuFJHl0df9CTjuXiW7S/nTDU9zcfcfc1mfa3nunlfxV9f9dB8MBLnp5LvYtm47VeXVVJRUUl5cwX2XPs7m1VsTGccYY9JKY+MATgR+HGP788BvD/bEqvoxkLR5kf1Vfq4/+lZ2bNxF0B9ZWu2lB97km9kreOC93+zdb+EHi6murK43fU8oGOLdv3/I1Q98P1kRjTHGUY3dAaiq1luUMrqtPHmREmPmK5+ze3vx3os/QHWlnyWzl7Ni/pq924oLS9Bw/QfhwUCIXVv2pCSrMcY4obECsEFExuy/UUSOAQqTFykxlny2nKqy+qNzNaysrFUARpwwlFAwVG+/7PwsjjrzyKRmNMYYJzVWAG4AXhWRW0VkYvT1K+BV4FepiXfgug/ohi/GKFu3x03XPvt6E3Xt05kzr55Idt6+1qisHB+9BvdgwnePTklWY4xxQqPjAESkMzAZOBzIBb4BnlLV1amJV1dzBoIV7yzhigHXUVFSuXeby+2iU68OPLPqiTozbaoqn74+h2l/eZ/K8mpOvuQ4zvrxKbZ0ozHmkHDAA8HSSXNHAq/+ch0PXvEEm1ZtBVWGHTuYW569gU49OxxUjs2rt1K4aRdz3/mSD56dScAf5LhJ4/jRfZfSrkvbgzq2McYkWkYWgBpFhcV4vB7y2x7cQKs924u4fdJDrP1qPcFAqM7EcG6Pm/bd2vKPpY+Tk5d9UOcxxphEOpiRwC1e205tDvriD3DbuQ+wasFa/FWBerOChoIhSneX8dGLsw/6PMYYkwoZUQASYdOqraz/ZmPMHkM1qsqrWT53VQpTGWPMgWtsKojzG/tGVX098XHSV3FhCW6vGyob3ifSe6h76kIZY8xBaGwk8DmNvKdEJobLGP1GHUYoWH8xmNo8Pg+n/7DhFcCMMSadNFgAVPXKVAZJdzl52Vz9wGX8/ZbnqY4uCi8uQcOK2+Oi/xF9+eXTP6N1h4xfOtkY00I0uSawiPQgMhagC7B31RNVvSqJudLSpOvOpPfQnrz22DR2by3i6G+P4exrTiGvdS65rXKcjmeMMc3SZAEAXiKyePv3iSwHORoYmMxQ6Wz0xBGMnjjC6RjGGHPQ4ukF1CE6X38x8BbwG2BQUlMZY4xJunjuAGrmQ1gEXAC8C7RLVqCWprqymv9O+ZjZb82jbafWnDv5DIaNt/pojEl/8RSAe0SkHXA3kYv/E0TuAjJeVUU1NxzzK7as2U51RTUiwqdvzOEnj1zBOT893el4xhjTqCabgFR1iqruUdVVqjpAVTup6pOpCJfu3nt6BlvWbNvbK0hVqa7w8+QvplJR2siAAWOMSQNNFgARGSYi00Rkk4isEpE/iUj7VIRLhZ2bd7Fi/hoqy5p/wf709TlUV/jrbff4PCyfYyOCjTHpLZ4moBeBe4GLiCwGfxUwFfh2EnMlXXlJBfd+7zEWfbwEr89DKBDi+7dfwPf+7ztxH6NNx9h9/kOhMHkJmHvIGGOSKZ4CgKq+Ev1rJfCYiPwkeZFS46Ef/JFFHy0hUB0gUBVZKP75375GjwHdmPDd8XEd49zJZzDnnS/3NgEBiAjtOrdh0Jh+Ccu6eMd2/jj3c1bu2sXQjp340ZFj8IdCtM3JYUiHjohI0wdJc+XBCt7e+h/m716Az5XFKZ2/xYmdT8AlNl2VMckSTwFYICKnATXzMOcAO6MPhkVVdyctXZKU7C5l3nuLCFQH6myvKq/m5YffirsAjDrxcH5w10VMue0lPD4PGlZad2zFfe/++qAvyltLS3ly4Tw+WreGzaWlhKPTdhcUF/HemlXkerwo0LN1a54+73x6tGp9UOdzUnWomruW3MMu/26C0WWoX9j4MqvKVnNN/6sdTmfMoSueAvCt6Gt/C4nMCZS4j7opUrq7DLfHRaC6/nt7thU161gX/uJczrjqZJZ+vpJW7fMZevTAg774by4p4dsvTqU8ECAYjj3/UEUwUrzW7NnNlW+9xvuX/bDF3gl8vusLigJFey/+AP6wn7m753Nuj3Pomt3FwXTGHLqaLACq2jcVQVKpa5/OeLO8VJXXrQAut4vRpzR/lG+rdvkcfdboRMXjsS9mU+r37/3U35iwKltKS1m+aydDO3Zqcv90tLRkOdXh+g/TXeJibdk6KwDGJEmDDawicl70zytivVIXMfHcHjeT/3AVWbn7Fo13e93kts7h+7dd6GCyiM82bYjr4l/DLUJRZcvtdtopqxNucdfbLgjtfG1TH8iYDNHYHcDRRKZ+OCrGe0qkJ1CLNfHSCXTu1ZGXH3qT7QWFHHHScC66+byDXi84ETrm5LKtrCzu/QPhMCO6dE1iouQ6qfMJTN8+nZDuW2zHhYtW3lYMbmWjqo1JlibXBBaRrgCqui36dWfAVfN1Kh3omsAtzdsrl/N/H7xPZTBYZ7sLCBP5xB+K/rvleDz88pjj6dOuHQVFRQzt2IlxPXq2uOcBy0qW8+Sav1MeKkc1TO/c3kwecC0dsg6ZISfGOKahNYHjeQj8OvBToOaC3waYAhyXsHQtWFFhMdUVfjr3Tlx3zLMHDqaguIg/zZuDx+UiEAoxtntPbhx/LN3zWzFt5XKmr11Nh9xcJg0exgOzZ7GzopxgOIzb5WJA+w48/50LyfP5mj5ZmhjaegiPHfEwO6p34HP5aOez6aaMSbZ47gBWquqg/bYtU9WhSU0WQzrdAezcspv7Ln2c5V+sQtwu2nZqzc3PXMeoEw9P2DnK/H7W7N5F57x8urWKPejs6n+/wayCdQRr/Tv63G4uGT6SO048OWFZjDEtV0N3APGMstklIsNrHehwGl0Z99Cnqtw08S6WzF5BwB/EX+lnx4ad/Obb97Nt/Y5mH29XRQVzN29ic2lJne35Ph+junZr8OLvD4WYVbC+zsW/Zvuby5c1O4cxJrPE0wR0A/CGiGwhsiJYL6BF9wI6WEtmL2fX5t2EQ3X76AcDQf7z1HR+dN9lcR3nq1lLefD+5yko3IV/bFfKDm/DcYf14Ykzv02O19vk96sqSuw7uJA2vn6xMcbEMw5gnogMAwYTKQArVTXGEKrMsWPjrlqLY+4T9IfYsjq+Z+NT73qFFx58g2BVkFwg+5s9eAa1ZvaP4c6ZH/LgKWc0eYwsj4fR3bozf8vmOmXA43JxWr8B8f0wxpiMFc9soFnA+cCp0ddkEfl5soOls8FH9ScUCNXb7va66TO8V5Pfv2NDIS8/+CahquDeOuLyh8ldWYJr6W7+vWI5/lD948fywCmn0zY7hxxPpJbner10ycvnluNPjPvnMcZkpniagN4GSoAlQHxXpUNczYRxn75RdzroUCDESw+8SZ/Dezc6n9CC6V/jctevvS5/mLzFuyk6vD1VwSA+d/3BUfvr27YdM394NW+tWMaa3bsY0bkrZw0cRJYnrnn+jDEZLJ6rRE8nevyku5umTEYVZrzwSZ3t/qoAD1/1J44+ezS+7NjdMHNb5SCu+m1I6oJwjocerVrTqhldOPN9Pi4bMap5P4AxJuPF0wvoaxEZmPQkLYzb7WbZnJUx3xMRln4e+z2Ao789hlgPEdTtInBMV+49+dQWN5DLHLjyYAUbKzZRGcroznXGAfHcARwDfCIiNf0bBVBVHZm8WOlvzVfr2b4udpfPcDiML7vhXjzZuVnc+/at3HbuA4TDYfyhEKFgiN6Tj+XP/3MZgzt0TFZsk0aC4SDPFjzP7J2f4RYPIQ1xateJXNTzAvsAYFIingIwIekpWqAZL37aQAdMcLndDDm68ZumEROG8sq2v7Noxjf4q/wcefJw8tokfxWx6mCQN1cs44O1a+iYm8tlI0YxvLPNtumE1za9wWc7vyCgQQLRqbA/2D6Ddt62nNb1VIfTmUzQYAEQkW6quhUavM5ltFAw1OBvZtJ1Z+ByNd265svyMu7MIxOcrGGVgQAXvPoi64v2UBkM4hLhrRXLuPukiVwwbHjTBzAJE9YwH+74CL/WnQbbH/bzztb3rQCYlGjsKlUz2+d/iPQE+k+t19uJOLmInCUi34jIChH5VSKOmSonfHc8vpz6D2q9WV7O/VnTffid8PKSxXsv/hBZS6AqGOSOj2dQGQg08d0mkUIawh9jDQSAsmD8M8EaczAaLACqWvMR5BeqOlJVR9R6HXT7v4jkAX8BTgEOB84UkcStqpJkw44ZzJk/Opms3CzEJbg9bnzZPn766BV06JaeE5m9u3plvRlGAdwu4avtKZ/cNaN5XV46Z3WO+V7fvD6pDWMyVjzPAB4Fmr9MVtPGAQtrTTP9L+AsIktNtgiTf38Vp1x+IrPfmIMny8PJ3zuenoO6Ox2rQW2ys2NuD6uSn6KZQ4v8xXy8Yyabq7bQP68fEzodT54nNyXnTjeX97mUP6z60947AUHwurxc0vtih5OZTBFPAVgkIoNVdUWCz90dqN2NphCo9+RURK4BrgHo3bt3giMcvMFj+zN4bH+nY8Tl8pFHMHtDQZ27AAE65ORyeKfYn0YTaUPFRu5b+gDB6EPPRUVf8Z+t73Ln4bdl5Lz/I9oM55YhN/HvLW+zpXIrffJ6c173c+iZ29PpaCZDxNsL6BMRqWkjSGQ30P1nLKv3MVRVnwKegsh00Ak4Z8aa0LsPPx07jj/Pm4PX7UYVWmdl8c/zzk9Jt8On102hMly192t/2E8wHOClja8wecBPk37+dNQ/vx83DrrB6RgmQ8VTAJI1qcw2oHaH907sW3Qmrc15ZyFvPvEOxTtLOW7SUUy67syUdOGMZe2e3Uz96ksKios4tmdvLh4+ktZZWQ3uf/24Y7hk+CgWbt1M2+wcxnbvgSsFF39/2E9B+YZ628MoXxctTvr5jTH1NdYNtBVwB5FmmVnA46qayLmA5gD/iC4xuRu4APhNAo+fFM/f+xov3v8G1RWRCVELlmzk/X9+zF+/fJjcVjkpzfLphgJ+8vabBEIhgqrM2byJpxctZNoll9Mxt+F29Y65uZzWP7WDu124IncZMe7hvK6mp742xiReY91A/wlUAY8Aw4F7EnliVS0Drgc+ApYC01V1ZiLPkWglu0t54d7X9l78ITL3z66te/jPU9NTmkVVuWn6e1QGg3sXhKkKBtldWcETcz9PaZZ4eFweRrc9Eo/UneDOK15O7GRjDY1xQmNNQMNV9QIAEZkLLAYS2ldfVacB0xJ5zEQqKypn5iufUbSjhFEnDaOyrAqPz4u/qm6feX+lnznvLOTCX5ybsmybS0sorq6qtz0QDvPB2jXcddLElGWJ15V9r6BweSFbq7YhRJp/BrcayKQeqfu9GWP2aawA7H1Aq6rVIlK/A/khbOnnK7jljN+iIcVf5ceX42PAkX0Jx5inX0To2D21vVhyvV7CDazn3JyZRFMpz5PHnYffxtrydWyv2kGv3J70aqTHi6oyf88CZhZ+QljDHN/xOMZ3GIdL4pnD0BjTlMYKwBARqVmkVoDc6Nc1vYBaJz2dQ8LhMHd99xEqS/d9wq4qr2bVgrXktc3DXxWosxykL8fLpOvPjPv43+zYzspdO+nfrj0ju3Q9oB447XNyGdutB3O3bCIY3pclx+PhB6NSN71Ec4kI/fP70T+/X5P7/m3t08zfs4DqcKTJbXXZGubunsv/DLzeJkszJgEaLACqmrEfs9Z+VUBlWf3mlepKP72H9qBt59ZsXrUVt8eNhpXJf7iKIeOafqhaEQhw1VuvsXjHdkQEVRjcoQPPTLqAVo303GnI42eczRVv/osNxUW4RAiEQpw3eCgXD9/XQ1dV2VpWSr7PR+us2APB0lFB+Qbm7ZlfZ7qE6nA1S0uWs7x0BUNbD3EwnTGHBls2qpnKiyv465cPs3Pzbkr3lDPgiD4NLvyyvwdnz2LR9m11lntcurOQu2fN4OFT47+DqNExN5f/XHI53xTuYGtpCcM7d6F7q303Zh+tX8uvPvwvxdXVhFU5vtdhPHramQ2OCE4ny0qWEY7R6aw6XM2S4qVWAIxJgIz9lN+YfqMOIyc/9kWycNMuLu19Lf6qAMPGD4r74g/wxrKl9db69YdCTFu5Am2gPb8pIsKIzl04rf/AOhf/5TsLmfzONLaXl1MVDOIPhfhkw3quefvNAzpPquV68nBL/c8nXvGS7813IJExhx4rADG4XC7ueO2X5LTKxu2t220xUB2krKicey76XbMv2v5w7GEUwXA44XNuP/3lAgL7FZtAOMziHdtZu2d3gs+WeEe1H4PEWDVNRBjf/mgHEhlz6LEC0IBhxwzmhYK/0rZj7GfdOzftYlsDK4I15LheveuNuhVgXPeeCR+Nu764iFCMAuV1udhSWprQcyVDjjuHXwz+X/I9+WS7ssl2ZZPrzuWGAZNp62vjdDxjDgn2DKAR+W3zyG+Xx66te2K+39w7gDtPnMh5Lz9HVTBIVTBItseDz+3mtyefkoi4dYzv0ZOv93veAJEmpyEdOyX8fMkwqNVA/nDk71hTtpawhhmQ3x+Py/6TNSZR7A6gCaf94KSYC7906NGebv2at5RirzZt+OiKH/Hz8cdxzqAh/M+4Y5hxxVX0a5f4MQRXjBpNvs+Hu9adRY7HwyXDRzU6TQREClthRTnl/tgLlqSSW9wMajWQIa0H28XfmASTA3346ISxY8fq/PnzU3pOf3WAW067h9VfrqOqvJqsXB9uj5tHZtzJgCP7pjRLc20tLeXxOZ8xs2AdbbKy+dGRY7hw2PBG+9B/UrCeW2f8l50VFaBwSr/+3D/xtAPqpmqMSQ8iskBVx9bbbgWgaarKlzO+YelnK+jQvR0nXnRsyid+S4XlOws5/5UXqKq1XoDP7WZstx48d/6FDiYzxhyMhgqA3VPHQUQYPXEEoyce+MJoJdVVLNq2jbbZ2bTPzqE8GGBAu/a441g8PlX+sXB+vZ5D/lCIhdu2sL5oD33apudSl8aYA2MFIAWeWjCPx76YjcfloiK6+Hq2x0O2x8tDp57OxL7psaLY2qI9DfYc2lxaYgXAmENM+nz8PER9tnEDv5/zGdWhEOWBAEpkSvzKYJA9VZXc8O7brNm9y+mYABzdoyfeGHck/lCIwR1aRs8hY0z8rAAk2TNfLayzBu/+/KEQzy3+KoWJGnblEWPI9fpwUbfn0PeGj2yy51AmqAhW8Oamf/ObxXdw/7KHmL974QGP4DYmHVgTUJLtrqxs9P2QKptLSxrdJ1U65eUx7ZLv88hnn/LpxgLaZGVz1ZFjuHR4IpZ/btmqQlXcseRu9vj3ENBIQV9Xvp7TupzCBb3OdzidMQfGCkCSnd5/IEsKd9TpWbO/jcXFFBQVcVjbtqkL1oCerdvw+BlnOx0j7cwq/IQif/Heiz9EJqZ7d9v7nNb1FFp7D9nZ0c0hzJqAkuyS4SPp0ao1WW53g/us3LWTSS8/R2FFeULPHValIhCwZooE+Lp4MX6tPzDO6/KypmytA4mMOXhWAJIsz+fjtyefikKMqc0iFCjz+7nxvXcSMlFbKBzm4dmfMPKvTzDqr08wYcrf+O+aVQd93EzWzts+5uR0YQ3bp3/TYlkBSIHbP/oAfyjU6IyfIVU+37SBs194lt9/8dlBne++T2cy5auFVAQChFTZUlrKje+/w5xNGw/quJns1K4T8bq8dba5cNHO145+eek9ItyYhlgBSLKiqkrWF8WeTG5/ClSHgjy5cB5LC5s302iNikCAF7/5ul7Po8pgkN/P+fyAjmmgd24vru57FTnuHLJd2fhcPnrl9uTmwb+w5SlNi2UPgZPM62q47b8h/mCIt1euYHCHjgTDYbI88f8zFZaXNzi19Lo4C5GJ7egORzGm3ZFsrNxErjuHLtnNmwzQmHRjBSDJ8nw+jut1GJ9sWB9zlG1sysyCtfzjy/kEwmFcIhzWpi2/nnASJ/dtfDH1rvkNr5bVq7XNo3+wPC4PffP6OB3DmISwJqAUuHzkEYSb0xNHhFW7dhEIh4FIb551RXv42Tv/ZtrK5Y1+a5bHw7Vjx8Uc0bt4xzYWbt3SrOzGmEOXFYAUeHrRgiaXfHSJ4HG5yHK7ESAYo2D4QyHu+2Rmk906rx0zjlyvt9726lCI+z+d2YzkxphDmTUBpcCKXTsbfM/ndnNU9x4c1+swFKV9Tg73fTKLUn91zP13VkQWec+JcYGvURUKUdbAYi4H+nDZGHPosQKQAv3ato8ssLIfn8vFWxdfxuBaSzRuLS3ljtCMBo+V6/U2+VA42+Mhy+PZO/NobR1z85qR3BhzKLMmoBT43/HHkr3fRTvH4+Hq0WPrXPwBurVqxVkDB+GJ0Yaf7XZzzZijmlxA3iXCD0eNJifGOScfdfQB/hTGmEONFYAUGN+zF3888xwOa9MWAVpnZfGzo47m58ccX2/fsCpel7teO3+W281Pxozj2rHxXcBvHH8slwwfRbbHQ47HS57Xyw3jjuHCYcMT8SMZYw4BtiRkigXDYdwiDQ4eemXJYu6aOaPOQC4XMLJLV16/+LJmn68yEGBXZQWdcvOaNZ7AGHPoaGhJSLsDSDGPy9XoyNGpX39ZbxRvGFi6s5DtZWXNPl+O10vP1m3s4m+MqceuCg4rrqri6UUL+GjdWjrk5rKzvP7DYgC3COWB2D17MpGqUhwoxuvykeexxWqMORBWABxUXFXF2S9MZVdlBdXRxdg9LhcukXoDx/J9WbYmb9SK0pX8be3T7PFHprYY0mowP+n/Y1p7WzmczJiWxZqAHPTMV1/WufhD5BmBqpIdXT/A63KR4/Hw49FjmfTy8wz+42OM/8dfmbJoIXsqK6huZKGZQ1FhdSGPrniMwupCghokqEGWlSznoeWP2LoHxjST3QE46OP1a+tc/Gvk+XxcNGw4m0tL6Nm6DWO6defn/31376piO8rLuXvWR/x21kd43W7OGzyUO086mWxPw4PDDhUfbv+IYLju7yxEiB3VhawtX0f//MbnSjLG7GMFwEGd8/Nhe/3twXCYS4aPpH/7DgBc+dZrMZeUDBOZ3uGtFcso8/v541nnJDmx87ZVbSdE/aIpCLv8u+iPFQBj4mVNQA666ogx9QZruUUY0K793os/wIqdDU8lAZEi8OG6NRSWJ3ZJyXQ0pNVgfC5fve0hDdEnt0/qAxnTgjlSAETkFRFZKyIrReQJydAVNcb16MmvJ5xEjsdLvs9HtsfDsE6d+fu536mzX7927Zs8ltftZmtZabKipo0TOh1PrjsXN/vWWfC5fIxtP5rO2Z0a+U5jzP6cagJ6FriYSAF6GzgXeMuhLI66dMQozh86jGWFhbTNyaFvjJ4+/zv+WBa+uSVmM1CNQCiUEb2Ecj253HX47byx+S2+LFpEtiuLiV1O5tQuE52OZkyL4/hIYBF5FFipqk82te+hMBL4QM1cv467Z30Uc1WvHI+HK0Ydyf8dd4IDyYwx6a6hkcCOFgARyQW+Bs5W1RUN7HMNcA1A7969xxQUFKQwYfoJhcOsK9rDA5/OYv7WzbTJyuaILl3J9XoZ1qkzk4YMo1VWltMxjTFpJOUFQEQ+ADrGeOssVd0Sbfd/EVimqnfFc8xMvgOIZXNJCZNefp6KgJ/KYJAcj5ccr4c3LrqMXm1s+UdjTERDBSBpzwBU9ZRGwgjwJFAU78Xf1HfnzBkUVVXuXWu4MhigOhTkto8/YMp533U4nTEm3aW8F5CIuIEpgB+4NtXnP5TMKlhXb6H5sCqzNxTYqFhjTJOc6AXUC7gcWAksi/YAnauqVziQpUXzuFx7F46vzR1jMRljjNlfyguAqq7HBqAlxDmDhvDmimX4a00n4XW5OHvg4EannDbGGLALcYv2qwknMahDR3K9XrI9HnK9Xga078AdJ37L6WjGmBbA5gJqwVpnZfHWxZcxb8tmVu/eRf927RnXo6d9+jfGxMUKQAsnIozr0ZNxPXo6HcUY08JYE5AxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKMeng24OESkEnJgOtCPQ+LJczrFsByZds6VrLrBsByJdch2mqvVWTGpRBcApIjI/1kx66cCyHZh0zZauucCyHYh0zVXDmoCMMSZDWQEwxpgMZQUgPk85HaARlu3ApGu2dM0Flu1ApGsuwJ4BGGNMxrI7AGOMyVBWAIwxJkNZAYiTiLwiImtFZKWIPCFpMOeyiJwlIt+IyAoR+ZXTeQBEJFtEPhCRNdHfVVrk2p+I3CQi3zidozYR8YrIoyKyWkQ2ikg7pzMBiMgPov+drRSRf4lIfhpkGi0iX9f6uoOIvBfN+J6ItE+TXL+M/nsuF5F3RaReX3wnWQGI37NAf2AoMAA418kwIpIH/AU4BTgcOFNERjuZqZYHVbU/MAq4WESOcDhPHSJyHHCp0zli+DNQDgwEegNFjqYBRKQLcAdwjKoOAnYA1zuc6VFgOnWvXw8Db0QzvgHcmSa5FgEjVXUI8AmQVh+IrADESVWnaUQIWAp0dTjSOGChqm5T1SDwL+AshzOhqlWqOj3690pgNdDF2VT7iEhH4DHgp05nqU1EugLHAndqLU7nAnxAHlDzqX8b4HcuDqjqL4Ax+22eCLwc/ftLOPD/QqxcqvqBqlZEv1yM89eNOqwANJOI5ALnAR87HKU7kU9jNQpJs/+4op8exwNznM4CEG22ewa4GdjucJz9DQcUmBFt0ns+epfnKFXdSKRgLhORvwNHEblTSTcdVLUIQFWLAUeagJrwfeBDp0PUZgWglmjb9aIYr+7R9wV4GnhWVVc4mxaA8H5f+xxJEYOIZAGvAr+u+R8zDdwIfKaqHzsdJIbOwErgdGAYkQJ1h6OJABFpQ6S58xjgfaAfcLKjoWLb/24pbf5fABCRnwEdgH86naU2WxKyFlU9paH3ohf/J4EiVb0rdakatI3IRFM1OkW3OU5EfMBrwLuqOsXhOLX1BU4TkcsBL9BTRD5R1QkO5wLYA5SrajWAiLwJ3ORooohTgWWquozIXUAZMBn4j7Ox6tkjIvmqWhYtWrudDlRDRK4ALgfOiDYhpw27A4iDiLiBKUTaPq91Ns1ec4CjRKSziHiAC0iD28toE9k04BNVvd/pPLWp6vWqOjj6QG4isCpNLv4As4ETRKRP9OszSY+ms7XAhFq9asYCyx3M05AZwMXRv3+PNPh/AUBErgF+DJwZbZpKKzYSOA7R/ynXErlFrzFXVa9wJlGEiJwDPEDk0+xzqnq3k3kAROQkIk0F62ptfkNVb3UkUAOi/6Zvq+pwp7PUEJFTgEeJ/Ht+Dvys5o7ASSJyA3AdECLSq+UaVS11MM/dwCQivaWWAL8g0jHjeaAPsB64TFUL0yDXM9G3q2r2i34ASQtWAIwxJkNZE5AxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAJmVEJBydFXGliLweHbATa78PRaTHARz/fhH5zgFmmyIiFzTw3ggR+Tg6G+x6EXlGRLodyHnSgYi0jY5MbWyfPBH5TETSdkFzc/CsAJhUqlDVIdEZG5cBt8faSVUnqurm5h5cVW9V1TcONmRt0fmM/g3crKr9gEHALKBnIs+TYm2BBguAiBwDrCIy7485hFkBME55HxgkIn1EpEBEnhORJSJyenTu+T7R10YReTV65/ChiOQAiMhRIvKFiKyK/tldRP4oIj+Mvr9eRP4pIl+LyGIRGR7dfmX0k/xyEZktIr2ayDkZ+LuqzgVQVb+q/kNV50U/Sf8reqzPRGRY9Bx3isjb0VxrROR/RGRqdL9ZNZO8NZKxp4hMj+7/31pzUU0RkZdEZIGIbBCRi2pCisjt0XmrVorIzdFtPxSRmdHXOolMVwxwPzAwevy/7f8Dq+rnqtqdyOhkcwizAmBSLjpR3FVEPklDZLrh+1T1cFV9f7/ds4DboqMni4FJ0bmGXgR+oqoDiUztHGtE4yuqOhL4LZER0xD5ND8gerxpRC7wjTkcmNvAe3cAX0WPdQswtdZ7ZcCJRKZ0eAh4IrrfZiKzyTaW8QlganT/Z4E/1Np/K3A08G3gHoBo01Ub4Egis4peKCKDa33PJCLrWHwvWkxuJTINxhBV/XETP785hFkBMKmUKyLLiQyT3wY8Ht2+TVWXNvA9O1S1Zu6ZJUSmwR4MbFXVrwBUdZGqbo3xvfOif04DahbLaQ9MlchqYNfR9FoFuY28dxLwXDTDLKCTiLSOvjc/Oo3DaiCgqjVZVgG1nx/EyjiBSIEj+ueJtfafHV3/oeZ3AXAGcCGRZrWvo8fvF31vsaruUdUqItOZtNhnFybxrACYVKp5BjBAVW9R1UAzvz8ESPTVHD6gMvr394B3iVxs/zeOY31DZPGdeNQ7lqruP2V3uIFz1s7YpOiskjXHcQE3RX+3Q1S1p6q+G+Pban+PMVYATIu0EugtIiMARGRQ9GHt/nKif15JZKk+iDwAfQcIsO8Td2OeAiZLZBlJRMQTbVsfDcwkurSkiBwPFKpqSTN/llgZP2XfzJYXE1lKsDHTgeskulaviBzRRC+lIqCziGSJOL+2tXGOrQdgWhxVrZLInP5Tow+F9wDfjbHryyLSAVgD1Mzc+hvgKyIXwZVE2uobO9cqEbkEeFAiC3rnE7lAvwfcBfwj2qy1B/jBAfw4sTLeAPxTRG4HNgI/bCLjiyIyCJgffb6yGbiokf2LRORf0XO+B1xd+30RGUdk1a/BRH7H76jqLw/gZzNpzmYDNYckEVkPjFXVnU5naUhLyGgObdYEZIwxGcruAIwxJkPZHYAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkqP8HtlqxUk8r5VMAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxA0lEQVR4nO3dd5hU5fn/8fc9bSu9SnNp0gUBe40o9hJFo0aNFU1QvzGWnybGEhO70cQ0iRV7wRJ7UGNDpQmi9N7LAsuybJl6//6YWdhlZ3dnYWbOLHO/rmsuds85c85nFzj3nOc853lEVTHGGJN9XE4HMMYY4wwrAMYYk6WsABhjTJayAmCMMVnKCoAxxmQpj9MBmqJ9+/ZaVFTkdAxjjGlWZsyYsUlVO+y6vFkVgKKiIqZPn+50DGOMaVZEZEW85dYEZIwxWcoKgDHGZCkrAMYYk6WsABhjTJayApAGGlqNBqahkRKnoxhjzA7NqhdQc6ORcnTrtRCYBuIDDaD55yMtbkVEnI5njMlydgWQQrrtNghMBfygZdE/K19BK152OpoxxlgBSBWNVEDVJCCwy4pKqHjakUzGGFOTFYBU0cr610VK05fDGGPqYQUgVVxtwdUu3grwHZr2OMYYsysrACkiIkiru4Fcdv6avSCFSIvfOJjMGGOirBdQCknOUdDuZbT8SQitAN8IpOBSxN3Z6WjGGGMFINXEOxBp/bDTMYwxpg5rAjLGmCzlaAEQEa+IPCwii0VklYi0cTKPMcZkE6ebgP4BrAP6OpzDGGOyjmMFQEQ6A4cBQ1RVncphjDHZyskmoMGAAp+KyAIReUFECnbdSETGish0EZleXFyc/pTGGLOXcrIAdAQWAicAA4ENwB27bqSq41V1pKqO7NChzpSWxhhjdpOTBaAEKFdVv6qGgbeAAQ7mMcaYrOJkAZgMHCUiRbHvTwKmOBfHGGOyi2M3gVV1m4hcDrwtIl7gG+BXTuUxxphs42g3UFX9GBjqZAZjjMlW9iSwMcZkKSsAxhiTpawAGGNMlrICYIwxWcoKgDHGZCkrAMYYk6WsABhjTJayAmCMMVnKCoAxxmQpKwDGGJOlrAAYY0yWsgJgjDFZygqAMcZkKSsAxhiTpawAGGNMlrICYIwxWcoKgDHGZCkrAMYYk6WsABhjTJayAmCMMVnKCoAxxmQpKwDGGJOlrAAYY0yWsgJgjDFZygqAMcZkKSsAxhiTpawAGGNMlrICYIwxWcoKgDHGZCkrAMYYk6XqLQAi0k5E/iwiL4jIZSIiNdbNTU88Y4wxqdLQFcAEoBh4CRgNfCQihbF1Uu+7jDHGNAueBtb1VNVTYl+/KyK/IloETgI09dGMMcakUkMFwCsiuapaBaCq/xCR7cC7QG5a0hljjEmZhpqA/gUcVnOBqk4AnseagIwxptmr9wpAVR+uZ/l4YHzKEhljjEkL6wZqjDFZKiMKgIjcJCI/Op3DGGOyieMFQEQOBy5wOocxxmSbRguAiDweZ1lS7gGISHvgEeDqZOzPGGNM4hK5Ajiy5jci4gNO3NMDx54sfha4GdjQwHZjRWS6iEwvLi7e08MaY4yJaWgoiF+KyA9ATxGZHXv9AKwE3knCsa8HvlbVzxraSFXHq+pIVR3ZoUOHJBzWGGMMNPwg2IvAB8A9wK01lm9V1dIkHLsnMFpELgK8QDcR+VJVj2zkfcYYY5KgoecASoFS4AIR6QzsQ/QBsHYigqp+tycHVtVrq78WkSLgXTv5G2NM+jR0BQCAiDwInA8sBcKxxQocm8JcxhhjUqzRAgCcBfRWVX+qQqjqcmBwqvZvjDGmrkR6Aa0CclIdxBhjTHolcgUA8HasB9AOqnpdCvIYY4xJk0QKwNMpT2GMMSbtGi0AqvqsiPQFeqnqR7EeQcYYY5q5RIaCuBF4Afh3bFEn4NVUhjLGGJN6idwEvgI4HCgHUNXvgW6pDGWMMSb1EikAlaoarP5GRAqAlHUJNcYYkx6JFIA3ROQhIE9EziE6PMSLqY1ljDEm1RK5CXy3iJwNtCI6Cug/VPXllCczxhiTUgk9B6CqE4GJKc5ijDEmjRLpBTRGROaLSKmIbBORMhHZlo5wxhhjUieRK4CHgNOAOaoaSXEeY4wxaZLITeBN2MnfGGP2OolcASwCHhSRyTUXquobqYlkjDEmHRIpAFVAW6LNQNUUsAJgjDHNWCLdQC9NRxBjjDHplUgvoM4i8pqIbIi9XheRLukIZ4wxJnUSuQn8DPA20CX2ejO2zBhjTDOWSAHooarPq2o49noB6J7qYMYYY1IrkQKwWkQuEBFX7HUBsCbVwYwxxqRWIgXgUmAMsCH2GhNbZowxphlLpBfQGuCsNGQxxhiTRon0AhooIu+IyGoRWSQi/xCRtukIZ4wxJnUSaQJ6CXgO6AuMJPpk8IRUhjLGGAOrt5Xy0NdfcuN/P+DtBfMIhMNJ3X+iw0FXzwFcCTwiIlclNYUxxphavlixnF++9zahSIRgJMKHixcxfsY0XjvnfPK93qQcI5ErgBkiMlpE2sZeXYFNItLGmoKMMSb5wpEI13/0PpWhEMFIdBzOilCQpSUlPPf9zKQdJ5ErgJ/EXrv6juiYQL2SlsYYYwwLNm8iEA7VWe4Ph/jPwvlcNfKgpBwnkV5APZNyJGOMMQnJ9XiIqMZdl5ek5h9IoACISB5wBrAPINXLVfXPSUthjDFmh56t29ClRUuWlmyhZhnI83i4cMiwpB0nkSagD4C1RHv/2KQwTVBZXsVXE6dQvHoz/Q/qw7BjB+NyJXLbxRiTzUSEx089gwsmvkp5MIiihCPK6fsN4Ix+/ZN2nEQKQCdVPSZpR8wSK+au4vqjbicYCBGo8OPLz6HXkB488PHt5OTlOB3PGJPherVpy1eXjWXyyhUUV5QzsktXilq3SeoxEvk4OlVEhif1qFngT+c/yvaS7VRtryISUaq2V7F41jJe//M7TkczxjQTHpeLo4t6Mmbg4KSf/CHBbqDA1yKyLfYqE5FtSU+yF9m0dgurF61j13s4gcogHz3zmSOZjDFmV4k0AV0LDAEWq9ZzWzrLVJRVMu2DmQT8QUaeMIw2HVvV3sB+TcaYZiCRArAJWGYn/6hpH83iD2MeQlwuVJVIKMzYBy/ijHEn7dimfdd2dO3dmRVzV9WqBb5cL6MvPrrW/iq3VzLhrtf45IUvQZWfnH8EF995LgUt89P1IxljspQ0dl4XkXeAMmB6zeVOdAMdOXKkTp8+vfENU6R8WwXndRlLVYW/1nJfno9/TLuPfQfunCdn2Y8r+c3RtxMKhKiq8JNXkMu+g7rz0Kd37LgJHIlEGHfQLayYs5qgPwiAN8dD175d+NfMB3C73en74Ywxey0RmaGqI3ddnsgVQPUZt0VyIzU/374zA3FJneWhQIhJz33BFff+fMeynoN78OKKf/L5a9+yafVm+h3UhxHH71+rG+iMSbNZs3DdjpM/QNAfYsOKjUx9fyaHnlbn78sYY5ImkSeB7wIQkcLY99uTcWARyQXeBXoCYeAZVb0nGftOlUBVgHhXTBqJUFVeVWd5XmEeJ14abxSNqEUzluKvDNRZXllWxeLvllkBMMakVCLzAfQXkWnAD8CPIjJNRAYk6fj3q2pvYCjwMxEZlqT9psTIE4YRCdd9Fi4nP4cjzzqkyfvr3LMjOXm+OstzC3Pp3LPjbmU0xphEJdIN9AngN6raU1WLgOtjy/aIqlap6qTY15XAYqDTnu43lTp0a8fFd55LTp4PV6wpKLcgh8N/ejD7Hz2wyfs74qcHkVuQs2NfAOIScvJ8HDmm6QXFGGOaIpGbwPNUdUBjy/YohEgnoqOLDlLVrfVt5/RN4GqLvlvKpAmfE6gKcNSYQzlg1BBE6t4bSMS6pRu4/xePsWDqYgD6Du/FzROupVvffZIZ2RiTxeq7CZxIAXgNmAU8H1v0c2CEqp6dpGA5wCTgKVV9Js76scBYgB49eoxYsWJFMg6bccpLywEoaFXgcBJjzN6mvgKQSBPQFUA74E3gDaA9cHmSQvmAicAH8U7+AKo6XlVHqurIDh06JOOwcakqS2evYO63CwkGgo2/IckKWhXYyd8Yk1b19gKKNct0U9UZwG9qLD8AqHvnsolEJJ9oUflUVe/f0/3tiRXzVvP70+6jZMNWXG4XIsLNz1zDYWcc6GQsY4xJqYauAO4D9o+zfH/gL0k49kHAMcClIjI/9ro3CfvdYduWMv5+3VP8rMuV/Lzolzx/92sE/LU/3YeCIW469i7WL9tAVbmfim2VlJdWcM8Fj7Jm8bpkxjHGmIzS0HMARwNXxln+AvDHPT2wqn4GpGxc5EBVgGsPvpWNqzYTCkSnVnv5vrf4cfIC7vvwth3bfffxD/gr/XWG7wmHwnzwxCdccd+FqYpojDGOaugKQFW1zqSUsWXlqYuUHJ+/+g1bNpTuOPkD+CsDzJk8nwXTl+xYVlq8DY3UvREeCobZvLYkLVmNMcYJDRWAlSIyYteFInIoUJy6SMkx5+v5VG2v+3SuRpSFNQrAkKMGEA6F62yXW5jDgScdkNKMxhjjpIYKwHXAayJyq4iMir1+C7wG/DY98XZflz774IvzlK3b46Zz0c7eRJ2LOnLSFaPILdjZGpWT56N7v64cefbBaclqjDFOaPA5ABHpCIwDBgH5wI/AeFVdnJ54tTXlQbDSTdu4uM81VGyr3LHM5XbRoXs7nl30WK2RNlWVr96Ywjv//IjKcj/Hnn84J195nE3daIzZK+z2g2CZpKlPAi+euYz7L36M1YvWgSoDD+vHLc9dR4du7fYox5rF6yhevZmp78/k4+c+JxgIcfiZB3H5PRfQplPrPdq3McYkW1YWgGpbi0vxeD0Utt6zB61KNmzl9jMfYOn3ywkFw7UGhnN73LTdpzVPzn2UvILcPTqOMcYk0548Cdzste7Qao9P/gC/P/0+Fs1YSqAqWGdU0HAoTNmW7fzvpcl7fBxjjEmHrCgAybB60TqW/7gqbo+halXlfuZPXZTGVMYYs/saGgrirIbeqKpvJD9O5iot3obb64bK+reJ9h7qkr5QxhizBxp6Evi0BtYp0YHhskavofsSDtWdDKYmj8/DCZfUPwOYMcZkknoLgKpems4gmS6vIJcr7vs5T9zyAv7YpPDiEjSiuD0ueg/ryY1P/YqW7bJ+6mRjTDPR6JzAItKV6LMAnYAds56o6mUpzJWRzrzmJHoM6MbER95hy7qtHHzqCE4ZexwFLfPJb5HndDxjjGmSRgsA8DLRydsvJDod5HCgbypDZbLho4YwfNQQp2MYY8weS6QXULvYeP2lwNvAbcB+KU1ljDEm5RK5AqgeD2EWMAb4AGiTqkDNjb/Sz3+f+YzJb0+jdYeWnD7uRAYeYvXRGJP5EikAd4tIG+APRE/+jxG9Csh6VRV+rjv0t6xdsgF/hR8R4as3p3DVQxdz2tUnOB3PGGMa1GgTkKo+o6olqrpIVfuoagdVfTwd4TLdh099ytol63f0ClJV/BUBHr9hAhVlDTwwYIwxGaDRAiAiA0XkHRFZLSKLROTvItI2HeHSYdOazSyYvoTK7U0/YX/1xhT8FYE6yz0+D/On2BPBxpjMlkgT0EvAn4BziU4GfxkwATg1hblSrnxbBX867xFmfTYHr89DOBjmwtvHcN7/+2nC+2jVPn6f/3A4QkESxh4yxphUSqQAoKqvxr6sBB4RkatSFyk9HvjF35j1vzkE/UGCVdGJ4l/440S69tmHI88+JKF9nD7uRKa8P3NHExCAiNCmYyv2G9EraVnnL1nPM699y7JVm+hb1IFzTxtJKBimZYs8eu/bHhFpfCcZrjxUwbvr3mP6lhn4XDkc1/EnHN3xKFxiw1UZkyqJFIAZIjIaqB6HOQ/YFLsxLKq6JWXpUmTbljKmfTiLoD9Ya3lVuZ9XHnw74QIw9OhB/OKuc3nm9y/j8XnQiNKyfQvu+eB3e3xS3ri5jBffmsrX05ewflMZkdi8xWvWb+WzbxeRm+MFoHOHljx029l07tByj47nJH/Yz11z7mZzYAuh2DTUL656hUXbFzO29xUOpzNm75VIAfhJ7LWr74iOCZS8j7ppUrZlO26Pi6C/7rqS9VubtK9zbjidEy87lrnfLKRF20IGHNx3j0/+6zeWcumNE6isChIKxx9/qCpWvFau3cKNf5zIc49e0myvBL7Z/C1bg1t3nPwBApEAU7dM5/Sup9E5t5OD6YzZezVaAFS1ZzqCpFPnoo54c7xUldeuAC63i+HHNf0p3xZtCjn45OHJiscTr0ymvDKw41N/QyIRZX3xNpas2ESfGnMdNydzt83HH6l7M90lLpZuX2YFwJgUqbeBVUTOiP15cbxX+iImn9vjZtxfLyMnf+ek8W6vm/yWeVz4+3McTBb13Q+rEjr5V3O7hW3NuNtph5wOuMVdZ7kgtPG1Tn8gY7JEQ1cABxMd+uHAOOuUaE+gZmvUBUfSsXt7XnngLTasKGbYMYM59+Yz9ni+4GRo3SqfjZvLEt4+FIrQv0/nFCZKrWM6HsWkDZMI687Jdly4aOFtQb8W9lS1ManS6JzAItIZQFXXx77vCLiqv0+n3Z0TuLn5ZPJ87v37h1T5Q7WWuwQiCm6XEI5dIeTmeBh7wRF036ctq9dvpU9RB4YN7Nbs7gfM2zafx5c8QXm4HNUIPfJ7MK7PL2mXs9c8cmKMY+qbEziRm8BvAFcD1Sf8VsAzwOFJS9eMbS0uxV8RoGOP5HXHPPawfqxeV8KEiVPwuF0EQ2H2H9CNK88/nI7tWjDpq/l8OXUxbVvnM/rIgfzjuc8pKS0nFIrgdrso6taOv9x5Lvl5vsYPliEGtOzPI8MeZKN/Iz6XjzY+G27KmFRL5Apgoarut8uyeao6IKXJ4sikK4BNa7dwzwWPMv/bRYjbResOLbn52WsYevSgpB2jojLA8tWbad+2kI71TDRz8z1vMGXWMsLhnX+PXq+bM44fyq8vPzZpWYwxzVd9VwCJPGWzWUQG19jRIBqcGXfvp6rcNOou5kxeQDAQIlAZYOPKTdx26r2sX76xyfvbWlzK7C/msnFlca3l+Xk+Bvbdp96TfzAYZsqs5bVO/tXLP/pibpNzGGOySyJNQNcBb4rIWqIzgnUHmnUvoD01Z/J8Nq/ZQmSXPvqhYIj3xk/i8nt+ntB+vv98Dn/55XhWL1yHL9dLJBxhxPFD+d3L15Obn9Po+xWFeq7gds1mjDG7SmQ00GnAQKLTQo4D+qvql6kOlsk2rtpcY3LMnUKBMGsXJ3ZvfMJdr3LL6LtZNX8tGomOIhr0h5gx6Xv+du2TCe3D5/UwqF8Xdr314Ha7OPLgPgntwxiTvRIZDTQHOAs4PvYaJyK/SXWwTNbvwN6Eg+E6y91eN0WDuzf6/o0ri3nl/rcIxdlH0B/i05e+IhgIxnlnXbf+6kRaFuaRmxO9mMvL9dK+bSHjLj46ofcbY7JXIk1A7wLbgDlA3TNWFqoeMO6rN2sPBx0Ohnn5vrcoGtSjwfGEZkyajctdf+2NhCMEKgN4fd5Gs3Tv0obX/nkl//1iLivWbKFfr0785LB+5PgSGufPGJPFEjlLdHOix0+mu+mZcajCpy/Wbg0LVAV58LK/c/Apw/Hlxu+Gmd8iD3HV32W0074dyG+Zn3CW/DwfZ54wLOHtjTEGEusFNFtE+qY8STPjdruZN2Vh3HUiwtxv4q8DOPjUEcS9iQB4c738+l9jm92DXGb3lYcqWFWxmspwVneuMw5I5ArgUOBLEanu3yiAqur+qYuV+ZZ8v5wNy+J3+YxEIvhy62++yc3P4U/v3srvT7+PSDhC0B8kHIow4JC+/Prxq+g5uEeqYpsMEoqEeG7FC0ze9DVu8RDWMMd3HsW53cbYBwCTFokUgCNTnqIZ+vSlr6jvETqX203/gxu+aBpy5ABeXf8Esz79kUBVgAOOHUxBq9TPIuYPhJj0xTy+nBZ9kvjME4bRr5eNtumEiavf5OtN3xLUEMHYUNgfb/iUNt7WjO58vMPpTDaotwCIyD6qug7qPc9ltXAoXO9v5sxrTsTlarx1zZfj5aCTDkhysvpV+YNc/dsXWb2uhCp/CJdL+O8X8/jNlcdxyrGDG9+BSZqIRvhk4/8IaO1hsAORAO+v+8gKgEmLhs5S1aN9vke0J9B7NV7vJuPgInKyiPwoIgtE5LfJ2Ge6HHX2IfjijLXjzfFy+q9OdCBR4975+AdWxU7+EJ1LwB8I8cgTn+yYYMakR1jDBOLMgQCwPbQ9zWlMtqq3AKhq9UeQG1R1f1UdUuO1x+3/IlIA/BM4DhgEnCQiyZtVJcUGHtqPky4/lpz8HMQluD1ufLk+rn74Ytrtk5kDmX32zUL8u4wwCtHRRecuWudAouzldXnpmNMx7rqeBUXpDWOyViL3AB4Gmj5NVuMOAr6rMcz068DJRKeabBbG/eUyjrvoaCa/OQVPjodjzzuCbvt1cTpWvVoUxh9eIqJKQQJDTyTD1kApn238nDVVa+ld0IsjOxxBgSfxLq97k4uKLuCvi/6+40pAELwuL+f3+JnDyUy2SKQAzBKRfqq6IMnH7gLU7EZTDNS5cyoiY4GxAD16ZF7vmH4je9NvZG+nYyTk7JMOYPrslbWae0SgTat89usZ/9NoMq2sWMU9c+8jFLvpOWvr97y37gPuHPT7rBz3f0irwdzS/yb+s/Zd1lauo6igB2d0OY1u+d2cjmayRKK9gL4UkepBbpLZDXTXEcvqNKqr6nhgPESHg07CMbPWgUOLuPCnBzJh4hS8HjcKFObn8NBtZ6el2+FTy56hMlK14/tAJEAoEuTlVa8yrs/VKT9+Jupd2Ivr97vO6RgmSyVSAFI1qMx6oH2N7zuwc9KZjDbl/e9467H3Kd1UxuFnHsiZ15yUli6c8axcu4WJ789kzfqtDB/Sg9OP25/Cgvqbcy455zDOGD2UH+avpVWLPIb074qrgaeSkyUQCbCifGWd5RGU2Vt/SPnxjTF1NdQNtAVwB9FmmS+AR1U1mWMBTQGejE0xuQUYA9yWxP2nxAt/mshL976Jv8IPwIo5q/jo6c/418wHyW+Rl9Ys075fwa33v0kwFCYcVmbOWcVr787gqYcuok0DBalNqwKOauQ5hWRz4YpeZcS5hvO6Gh/zyBiTfA11A30aqAIeAgYDdyfzwKq6HbgW+B8wF5ikqp8n8xjJtm1LGS/+aeKOkz9Ex/7ZvK6E98ZPSmsWVeVPf/uAKn9ox4Qw/kCIktIKnn7tm7RmSYTH5WF46wPwiLvWcq94ObqDPWtojBMaKgCDVfW22Nj/VxP9hJ5UqvqOqg5S1f1U9Q/J3v+e2r61nPfGT+KFP07kx6/msWDqYjxxRugMVAaY8n56Oy+tL95G2faqOstD4QhfTVuS1iyJurTnxXTL60aOK4dcVw4+l4/+LffjzK6nOx3NmKzU0D2AHTdoVdUvInU7kO/F5n6zgFtO/CMaVgJVAXx5Pvoc0JNIuG4rmIjQvkt6e7Hk5XqJROLfEy/I0MngCzwF3Dno9ywtX8aGqo10z+9G9wZ6vKgq00tm8Hnxl0Q0whHtD+eQdgfhkkTGMDTGNKahAtBfRLbFvhYgP/Z9dS+glilP55BIJMJdZz9EZdnOT9hV5X4WzVhKQesCAlXBWlMu+vK8nHntSQnvf8HSDSxduYl9u7ZlQJ/Ou9UDp3XLfPYf0JXv564mVCNLbo6HMSdn7vN0IkLvwl70LuzV6Lb/XvoU00tm4I9Em9wWb1/C1C1T+b++19pgacYkQb0FQFWz9mPW0u9XUBmnecVfGaDHgK607tiSNYvW4fa40Ygy7q+X0f+gxm+qVlYFuPFPb7BgyQZEotP59urRnkduH7NbD2Ldef0pXH/X66xevxW3WwgGw4w+aiCnHbezh66qsnFzGfl5PloU5Db5GE5ZUb6SaSXTaw2X4I/4mbttPvPLFjCgZX8H0xmzd7Bpo5qovLSCf818kE1rtlBWUk6fYUX1Tvyyq38+9wXzFq0jUGMqyEXLNvLoU5/yu2sSv4Ko1qZVAU8/fDELlm5g46Yy+vXuRKf2Oy/MvpmxlPv/9V/KtlcRiSgHDt2X2647mZaFmV8I5m2bRyROpzN/xM+c0rlWAIxJgqz9lN+QXkP3Ja+ek2Tx6s1c0OOXBKqCDDxkv4RP/gAffj631skfIBgK8/FX81HdvWfcRIT+vTtz1MF9a538l6wo5raH/sOmLdvxB0IEQ2Gmfr+cW+57c7eOk275ngLcUvfziVe8FHoLHUhkzN7HCkAcLpeLOybeSF6LXNze2t0Wg/4Q27eWc/e5f27ySTsYZxJ4gFAowm6e/+v1yjvTCYZqHy8UirBgyQZWrtmS3IOlwIFtRyBxZk0TEQ5pe7ADiYzZ+1gBqMfAQ/vx4op/0bp9/Hvdm1ZvZn09M4LVZ+TQfevcvBSBYQO7Jf1p3NXrtsbtJeTxuNiwqSypx0qFPHceN/T7NYWeQnJdueS6csl353Ndn3G09rVyOp4xewW7B9CAwtYFFLYpYPO6krjrm3oFcP3lx3Llwuep8ofwB0Lk+Dx4vW5uuir5k38cMKg785asr3PVEQyG6VPUvp53ZZb9WvTlrwf8mSXblxLRCH0Ke+Nx2T9ZY5LF/jc1YvQvjuHZO18lUFl78o52XduyTxOnUuzSqTUv/e0K3vvkBxYs3UCfoo6cOmowrVsmfzjkMaccwNuTvqcsXEU4diWQm+PhtOP2b3CYCIgWtpLSCnJzvOQ7/EyBW9zs1yK9w1YYky1kd28+OmHkyJE6ffr0tB4z4A9yy+i7WTxzGVXlfnLyfbg9bh769E76HNAzrVmaauPmMp58eTJTZi6jsDCX804dwSmjhjTYh37qrOXc/8+P2FJaAQpHHNibW351QtrmCzDGJJ+IzFDVkXWWWwFonKoy89Mfmfv1Atp1acPR5x6W9oHf0mHJimLG3vpCrVnDvF43+/fvyl/uPNfBZMaYPVFfAbAmoASICMNHDWH4qN2fGK2svIq5C9fRqkUerVrmUVkVYN+u7XC7M+c+/Mv/mR73nsGPC9ayel0J3TJ0qktjzO6xApAGL749lSde/hq3S6jyB1GNtsfn+Lz89poTOTxDZhRbtXZLvT2H1hdvswJgzF4mcz5+7qVm/LCSp175mkAgRGVVcEd//yp/iNKySm7/8zusWL3Z2ZAxwwZ2x+up+08iGAzTe9/m0XPIGJM4KwAp9tp7M6jy1z+QaigY5s2Pvk9jovqdc+oI8nJ9uGrcJM7N8XD68Y33HMoGFaEK3lr9H2774Q7unfcA07d8t9tPcBuTCawJKMVKyyobXB+OKOuLS9OUpmHt2hTw5IMXMf7FL5n2/QpaFOZy7qkjOHP0UKejOa4qXMUdc/5ASaCEoEYL+rLy5YzudBxjup/lcDpjdo8VgBQ76qC+LFy6EX+g/quAtRtKWbN+K107t05fsHrs07EVd/z6VKdjZJwvir9ka6B0x8kfogPTfbD+I0Z3Po6W3r12dHSzF7MmoBQ7Y/RQOndoiW+XMYVqWrpyE1fc/BxbtpYn9diRiFJZFbBmiiSYXfoDAQ3UWe51eVmyfakDiYzZc1YAUiw/z8dNVx2PanTcn/pUVAa469H3kjJQWzgc4V/Pf8EJF/2VEy56jDFXj+eLKYv2eL/ZrI23bdzB6SIasU//ptmyApAGD/37Y4KhcIMjfoYjync/rOSSGyfw1CuT9+h4f3v2M15//zsqq4JEIsqGTWXc9eh7zJyzao/2m82O7zwKr6v2fNAuXLTxtaFXQWY/EW5MfawApNi2skpW1zOY3K4UCARCvPDWNBY1caTRapVVAf4zaXadnkf+QIinXvl6t/ZpoEd+d67oeRl57jxyXbn4XD6653fj5n432PSUptmym8Ap5vG4o2f2JggGw3wyeT69erQnHIng8yb+17Rla0W9Q0uvSrAQmfgObncgI9ocwKrK1eS78+iU27TBAI3JNFYAUiw/z8fIofsybdbyHaNyJuLbmct4+Z3phEIRXCJ07dyaay89hsNGNPzUcPu29c+W1aWjjaO/pzwuDz0LipyOYUxSWBNQGpx14gFxh1hoyLJVmwiFIgBEVFm1roTbHvwPH381v8H35fg8XPTTg/HEeaJ3/pL1/LhgbZNyGGP2XlYA0uDVd6c32grkcglutyvaXVQgHK77jkAwzN+f/azRbp0XnnUQeTl1x/Gvfr8xxoA1AaXF0pWb6l3n87rZf0BXDty/iIgqbVrm8bdnP2d7hT/u9pu3luMPhMjN8cZdD9EbvuWV8d+/aPnu3Vw2xux9rACkQfcubdmytaLOcq/Hxb/vv5De+3bYsWzj5jICT3xS777ycn2N3hTO8XnJ8XmorArWWde2tY3pY4yJsiagNLj8Z4eR46t90s7N8XDe6QfWOvkDdGzXgp8c1g9PnHkCcnweLjjjwEYnkHe5hHNOHk5uTt1jXnz2Ibv5Uxhj9jZWANJg+OAe3H3jaXTr3BoBWhTkcNFZh3Dl+UfU2TYSUTxuF5Fd2vl9Xjc/P/NALjrr4ISOefl5h3PG6KHk+Dzk5njJy/VyyTmHccqxg5PxIxlj9gI2JWSahcIR3C6p9+Ghdz+ezaNPfVrrQS6XwIA+nXn8vgubfLwqf5CS0gratSlo0vMExpi9R31TQtoVQJp53K4Gnxyd+OGsOk/xRhQWLS9m05btTT5ebo6XfTq2spO/MaYOOys4bNv2Kl57dwaTZyyhbauCekcEdblcVFTVHY0yW6kqpcFSvC4fBZ58p+MY0yxZAXDQtu1VXHrDs2wprdgxGbvb7cIlUuceQEGej26dbU5egAVlC/n30qcoCUSHtujfoh9X9b6Slt4WDiczpnmxAuCgie/PpKTGyR+iQzkD5Pjc+ANhPG4XHo+L888YyZX/73mWrCymdYs8LvjpQZxw5ADy8hrvFro3KfYX8/CCR/BHdl4Nzds2nwfmP8Tdg++0gdmMaYLsOXNkoG++W0qgxsm/WkGej1NGDWZ98Ta6dGzFkP5d+cNf3t8xq9imknL++tT/eOzp/+H1uBl91ECuv/xYchp4OGxv8cmG/xGK1P6dhQmz0V/M0vJl9C7s5VAyY5ofKwAOat82/kNZoXCEM44fyr7d2gFwwx8nxp1SUjU6vMN/v5hLeYWfu288PaV5M8H6qg2EqVs0BWFzYDO9sQJgTKKsF5CDzj1lRJ2Htdwuoahbux0nf4ClK4ob3E8gGGby9CVsLknulJKZqH+Lfvhcdcc5CmuYovyi9AcyphlzpACIyKsislREForIY5KlDbfDBnXnmkt+Qm6Ol4I8Hzk+D317duL+3/601nY9urZtdF9er5vizWWpipoxjupwBPnufNzsnGPZ5/Ixsu1wOuZ2aOCdxphdOdUE9BzwM6IF6F3gdOBth7I46szRQznp6IEsWlFMq8I8unep29Pn8vMO58cFa+M2A1ULhiJ022fv7yWU78nnrkG38+aat5m5dRa5rhxGdTqW4zuNcjqaMc2O408Ci8jDwEJVfbyxbfeGJ4F317czl/GXpz5l1dq6s3rl5ngYc/Jwrr7wKAeSGWMyXX1PAjtaAEQkH5gNnKKqC+rZZiwwFqBHjx4jVqxYkcaEmSccjrBqXQn/mPA5s+evoWVhLgP77kNerpe+RR054eiBFOTnOB3TGJNB0l4ARORjoH2cVSer6tpYu/9LwDxVvSuRfWbzFUA86zeWcuUtL1BZFaDKH50jIDfHw/j7fk6XTq2djmeMyRBpHwtIVY9T1WFxXtUn/8eBrYme/E1djzz5KaVllTvGDqryB9m2vYqHx3/scDJjTHOQ9l5AIuIGngECwC/Tffy9yZRZy+rMNRyJKNNmr2h02khjjHGiF1B34CJgITAv1gN0qqpe7ECWZs3jdu2YOL4md5zJZIwxZldpLwCquhx7AC0pjjtiAB99PpdgaOeTsR6Pi2MP62dj4hhjGmUn4mbsml8cQ68e7cnLjc4BnJfrpahrO359+bFORzPGNAM2FlAzVliQwxMPXMjseWtYtnoz+3Zty7CB3ezTvzEmIVYAmjkRYejAbgwd2M3pKMaYZsaagIwxJktZATDGmCxlBcAYY7KUFQBjjMlSVgCMMSZLOT4cdFOISDHgxHCg7YFNDhw3EZZt92RqtkzNBZZtd2RKrn1Vtc6MSc2qADhFRKbHG0kvE1i23ZOp2TI1F1i23ZGpuapZE5AxxmQpKwDGGJOlrAAkZrzTARpg2XZPpmbL1Fxg2XZHpuYC7B6AMcZkLbsCMMaYLGUFwBhjspQVgASJyKsislREForIY5IBYy6LyMki8qOILBCR3zqdB0BEckXkYxFZEvtdZUSuXYnITSLyo9M5ahIRr4g8LCKLRWSViLRxOhOAiPwi9u9soYi8LiKFGZBpuIjMrvF9OxH5MJbxQxFpmyG5boz9fc4XkQ9EpE5ffCdZAUjcc0BvYADQBzjdyTAiUgD8EzgOGAScJCLDncxUw/2q2hsYCvxMRIY5nKcWETkcuMDpHHH8AygH+gI9gK2OpgFEpBNwB3Coqu4HbASudTjTw8Akap+/HgTejGV8E7gzQ3LNAvZX1f7Al0BGfSCyApAgVX1Ho8LAXKCzw5EOAr5T1fWqGgJeB052OBOqWqWqk2JfVwKLgU7OptpJRNoDjwBXO52lJhHpDBwG3Kk1OJ0L8AEFQPWn/vVAwLk4oKo3ACN2WTwKeCX29cs48H8hXi5V/VhVK2Lf/oDz541arAA0kYjkA2cAnzkcpQvRT2PVismwf1yxT4+HAFOczgIQa7Z7FrgZ2OBwnF0NBhT4NNak90LsKs9RqrqKaMGcJyJPAAcSvVLJNO1UdSuAqpYCjjQBNeJC4BOnQ9RkBaCGWNv1rDivLrH1AjwFPKeqC5xNC0Bkl+99jqSIQ0RygNeA31X/x8wA1wNfq+pnTgeJoyOwEDgBGEi0QN3haCJARFoRbe48FPgI6AVk4qTTu14tZcz/BQAR+RXQDnja6Sw12ZSQNajqcfWti538Hwe2qupd6UtVr/VEB5qq1iG2zHEi4gMmAh+o6jMOx6mpJzBaRC4CvEA3EflSVY90OBdACVCuqn4AEXkLuMnRRFHHA/NUdR7Rq4DtwDjgPWdj1VEiIoWquj1WtLY4HaiaiFwMXAScGGtCzhh2BZAAEXEDzxBt+/yls2l2mAIcKCIdRcQDjCEDLi9jTWTvAF+q6r1O56lJVa9V1X6xG3KjgEUZcvIHmAwcJSJFse9PIjOazpYCR9boVTMSmO9gnvp8Cvws9vV5ZMD/BQARGQtcCZwUa5rKKPYkcAJi/ymXEr1ErzZVVS92JlGUiJwG3Ef00+zzqvoHJ/MAiMgxRJsKltVY/Kaq3upIoHrE/k7fVdXBTmepJiLHAQ8T/fv8BvhV9RWBk0TkOuAaIEy0V8tYVS1zMM8fgDOJ9paaA9xAtGPGC0ARsBz4uaoWZ0CuZ2Orq6q3i30AyQhWAIwxJktZE5AxxmQpKwDGGJOlrAAYY0yWsgJgjDFZygqAMcZkKSsAJm1EJBIbFXGhiLwRe2An3nafiEjX3dj/vSLy093M9oyIjKln3RAR+Sw2GuxyEXlWRPbZneNkAhFpHXsytaFtCkTkaxHJ2AnNzZ6zAmDSqUJV+8dGbJwH3B5vI1UdpaprmrpzVb1VVd/c05A1xcYz+g9ws6r2AvYDvgC6JfM4adYaqLcAiMihwCKi4/6YvZgVAOOUj4D9RKRIRFaIyPMiMkdEToiNPV8Ue60SkddiVw6fiEgegIgcKCLfisii2J9dRORvInJJbP1yEXlaRGaLyA8iMji2/NLYJ/n5IjJZRLo3knMc8ISqTgVQ1YCqPqmq02KfpF+P7etrERkYO8adIvJuLNcSEfk/EZkQ2+6L6kHeGsjYTUQmxbb/b42xqJ4RkZdFZIaIrBSRc6tDisjtsXGrForIzbFll4jI57HXMokOVwxwL9A3tv9/7/oDq+o3qtqF6NPJZi9mBcCkXWyguMuIfpKG6HDD96jqIFX9aJfNc4Dfx56eLAXOjI019BJwlar2JTq0c7wnGl9V1f2BPxJ9Yhqin+b7xPb3DtETfEMGAVPrWXcH8H1sX7cAE2qs2w4cTXRIhweAx2LbrSE6mmxDGR8DJsS2fw74a43t1wEHA6cCdwPEmq5aAQcQHVX0HBHpV+M9ZxKdx+K8WDG5legwGP1V9cpGfn6zF7MCYNIpX0TmE31Mfj3waGz5elWdW897Nqpq9dgzc4gOg90PWKeq3wOo6ixVXRfnvdNif74DVE+W0xaYINHZwK6h8bkK8htYdwzwfCzDF0AHEWkZWzc9NozDYiCoqtVZFgE17x/Ey3gk0QJH7M+ja2w/OTb/Q/XvAuBE4ByizWqzY/vvFVv3g6qWqGoV0eFMmu29C5N8VgBMOlXfA+ijqreoarCJ7w8DEns1hQ+ojH39IfAB0ZPtrxPY149EJ99JRJ19qequQ3ZH6jlmzYyNio0qWb0fF3BT7HfbX1W7qeoHcd5W8z3GWAEwzdJCoIeIDAEQkf1iN2t3lRf781KiU/VB9Abo+0CQnZ+4GzIeGCfRaSQREU+sbX048DmxqSVF5AigWFW3NfFniZfxK3aObPkzolMJNmQScI3E5uoVkWGN9FLaCnQUkRwR5+e2Ns6x+QBMs6OqVRId039C7KZwCXB2nE1fEZF2wBKgeuTW24DviZ4EFxJtq2/oWItE5HzgfolO6F1I9AT9IXAX8GSsWasE+MVu/DjxMl4HPC0itwOrgEsayfiSiOwHTI/dX1kDnNvA9ltF5PXYMT8Erqi5XkQOIjrrVz+iv+P3VfXG3fjZTIaz0UDNXklElgMjVXWT01nq0xwymr2bNQEZY0yWsisAY4zJUnYFYIwxWcoKgDHGZCkrAMYYk6WsABhjTJayAmCMMVnq/wPFkMmsEoXztwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -838,17 +838,15 @@
    ],
    "source": [
     "# Plot samples against first two principal components, colored by their cluster\n",
-    "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
-    "from sklearn.decomposition import PCA\n",
-    "pca = PCA(n_components = 2)\n",
+    "\n",
+    "pca = PCA(n_components=2)\n",
     "pca.fit(feat_vec_scale)\n",
     "print(pca)\n",
     "comp_dim = pca.transform(feat_vec_scale)\n",
     "plt.figure()\n",
-    "plt.scatter(comp_dim[:,0], comp_dim[:,1], c=y_kmeans) \n",
-    "plt.xlabel('Principal Component 1')\n",
-    "plt.ylabel('Principal Component 2')\n",
+    "plt.scatter(comp_dim[:, 0], comp_dim[:, 1], c=y_kmeans)\n",
+    "plt.xlabel(\"Principal Component 1\")\n",
+    "plt.ylabel(\"Principal Component 2\")\n",
     "plt.show()"
    ]
   },
@@ -863,7 +861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -890,7 +888,7 @@
        "  Text(0, 0, '')])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -911,12 +909,12 @@
     "# Show the weights of different features in the first two principal components\n",
     "\n",
     "pca_weights = pca.components_\n",
-    "fig, (ax1,ax2) = plt.subplots(2,1)\n",
+    "fig, (ax1, ax2) = plt.subplots(2, 1)\n",
     "fig.tight_layout()\n",
-    "ax1.bar(scalar_cols,pca_weights[0])\n",
+    "ax1.bar(scalar_cols, pca_weights[0])\n",
     "ax1.set_xticks([])\n",
-    "ax2.bar(scalar_cols,pca_weights[1])\n",
-    "plt.xticks(rotation=30, ha='right')"
+    "ax2.bar(scalar_cols, pca_weights[1])\n",
+    "plt.xticks(rotation=30, ha=\"right\")"
    ]
   },
   {

--- a/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb
+++ b/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb
@@ -1,1076 +1,956 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "AIMS2022_Python_Basics.ipynb",
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/knc6/jarvis-tools-notebooks/blob/master/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/knc6/jarvis-tools-notebooks/blob/master/jarvis-tools-notebooks/AIMS2022_Python_Basics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CQtxFkfIE6fD"
+   },
+   "source": [
+    "# Python Basics for Machine Learning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zCWOrnon5JI_"
+   },
+   "source": [
+    "# Table of Contents\n",
+    "1. Installing packages (matminer to load JARVIS 3D dataset)\n",
+    "2. Data manipulation with ``pandas`` package \n",
+    "3. K-means clustering using ``sci-kit learn``\n",
+    "4. PCA dimensionality reduction using ``sci-kit learn``\n",
+    "5. Plotting results using ``matplotlib``"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "V_ztSZ1xg4vr"
+   },
+   "source": [
+    "# Python Basics\n",
+    "Python is a highly modular language, which makes the use of external libraries to perform certian operations. We'll first go over the very basics of the pandas and plotly libraries, which will, respectively, be used for data-handling and plotting in the following example.\n",
+    "\n",
+    "## Data-handling with Pandas\n",
+    "Pandas is a Python package that defines the DataFrame object. DataFrames are ideal for reading, writing, storing, and manipulating information in a tabular format (i.e. information labelled by a row index and a column heading).\n",
+    "\n",
+    "\n",
+    "First, we'll fetch the JARVIS-DFT 3D Database, which contains the relaxed structures and DFT properties for about 55,000 compounds using the ``matminer`` Python package. First, we need to install the matminer package using the command below. NOTE: the leading exclamation point (!) indicates that the command should be run as a shell command rather than a Python command."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Uncomment the following line if you do have [matminer](https://hackingmaterials.lbl.gov/matminer/) installed in your environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install matminer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#Python Basics for Machine Learning"
-      ],
-      "metadata": {
-        "id": "CQtxFkfIE6fD"
-      }
+    "id": "1U2AG6Xag_bQ",
+    "outputId": "b3ecf5fd-b960-4bd6-dc6b-8775026d8119"
+   },
+   "outputs": [],
+   "source": [
+    "from matminer.datasets.convenience_loaders import load_jarvis_dft_3d\n",
+    "\n",
+    "dft3d_df = load_jarvis_dft_3d(data_home='.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TS2aJVrfCYyN"
+   },
+   "source": [
+    "Properties associated with each entry in the JARVIS-DFT 3D materials database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "sl7eZ4ltmtBB",
+    "outputId": "b9b32377-a880-436f-80df-3cacc085e29e"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "source": [
-        "# Table of Contents\n",
-        "1. Installing packages (matminer to load JARVIS 3D dataset)\n",
-        "2. Data manipulation with ``pandas`` package \n",
-        "3. K-means clustering using ``sci-kit learn``\n",
-        "4. PCA dimensionality reduction using ``sci-kit learn``\n",
-        "5. Plotting results using ``matplotlib``"
-      ],
-      "metadata": {
-        "id": "zCWOrnon5JI_"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "#Python Basics\n",
-        "Python is a highly modular language, which makes the use of external libraries to perform certian operations. We'll first go over the very basics of the pandas and plotly libraries, which will, respectively, be used for data-handling and plotting in the following example.\n",
-        "\n",
-        "##Data-handling with Pandas\n",
-        "Pandas is a Python package that defines the DataFrame object. DataFrames are ideal for reading, writing, storing, and manipulating information in a tabular format (i.e. information labelled by a row index and a column heading).\n",
-        "\n",
-        "\n",
-        "First, we'll fetch the JARVIS-DFT 3D Database, which contains the relaxed structures and DFT properties for about 55,000 compounds using the ``matminer`` Python package. First, we need to install the matminer package using the command below. NOTE: the leading exclamation point (!) indicates that the command should be run as a shell command rather than a Python command."
-      ],
-      "metadata": {
-        "id": "V_ztSZ1xg4vr"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install matminer\n",
-        "\n",
-        "from matminer.datasets.convenience_loaders import load_jarvis_dft_3d\n",
-        "\n",
-        "dft3d_df = load_jarvis_dft_3d()"
-      ],
-      "metadata": {
-        "id": "1U2AG6Xag_bQ",
-        "collapsed": true,
-        "outputId": "b3ecf5fd-b960-4bd6-dc6b-8775026d8119",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: matminer in /usr/local/lib/python3.7/dist-packages (0.7.4)\n",
-            "Requirement already satisfied: numpy>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from matminer) (1.21.6)\n",
-            "Requirement already satisfied: pymongo>=3.12.0 in /usr/local/lib/python3.7/dist-packages (from matminer) (4.1.1)\n",
-            "Requirement already satisfied: monty>=2021.7.8 in /usr/local/lib/python3.7/dist-packages (from matminer) (2022.4.26)\n",
-            "Requirement already satisfied: tqdm>=4.62.0 in /usr/local/lib/python3.7/dist-packages (from matminer) (4.64.0)\n",
-            "Requirement already satisfied: requests>=2.26.0 in /usr/local/lib/python3.7/dist-packages (from matminer) (2.28.1)\n",
-            "Requirement already satisfied: jsonschema>=3.2.0 in /usr/local/lib/python3.7/dist-packages (from matminer) (4.3.3)\n",
-            "Requirement already satisfied: scikit-learn>=0.24.2 in /usr/local/lib/python3.7/dist-packages (from matminer) (1.0.2)\n",
-            "Requirement already satisfied: six>=1.16.0 in /usr/local/lib/python3.7/dist-packages (from matminer) (1.16.0)\n",
-            "Requirement already satisfied: pint>=0.17 in /usr/local/lib/python3.7/dist-packages (from matminer) (0.18)\n",
-            "Requirement already satisfied: future>=0.18.2 in /usr/local/lib/python3.7/dist-packages (from matminer) (0.18.2)\n",
-            "Requirement already satisfied: pandas>=1.3.1 in /usr/local/lib/python3.7/dist-packages (from matminer) (1.3.5)\n",
-            "Requirement already satisfied: sympy>=1.8 in /usr/local/lib/python3.7/dist-packages (from matminer) (1.10.1)\n",
-            "Requirement already satisfied: pymatgen>=2022.0.11 in /usr/local/lib/python3.7/dist-packages (from matminer) (2022.0.17)\n",
-            "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=3.2.0->matminer) (0.18.1)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from jsonschema>=3.2.0->matminer) (4.1.1)\n",
-            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from jsonschema>=3.2.0->matminer) (4.11.4)\n",
-            "Requirement already satisfied: importlib-resources>=1.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=3.2.0->matminer) (5.7.1)\n",
-            "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.7/dist-packages (from jsonschema>=3.2.0->matminer) (21.4.0)\n",
-            "Requirement already satisfied: zipp>=3.1.0 in /usr/local/lib/python3.7/dist-packages (from importlib-resources>=1.4.0->jsonschema>=3.2.0->matminer) (3.8.0)\n",
-            "Requirement already satisfied: pytz>=2017.3 in /usr/local/lib/python3.7/dist-packages (from pandas>=1.3.1->matminer) (2022.1)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas>=1.3.1->matminer) (2.8.2)\n",
-            "Requirement already satisfied: packaging in /usr/local/lib/python3.7/dist-packages (from pint>=0.17->matminer) (21.3)\n",
-            "Requirement already satisfied: ruamel.yaml>=0.15.6 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (0.17.21)\n",
-            "Requirement already satisfied: plotly>=4.5.0 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (5.5.0)\n",
-            "Requirement already satisfied: networkx>=2.2 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (2.6.3)\n",
-            "Requirement already satisfied: scipy>=1.5.0 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (1.7.3)\n",
-            "Requirement already satisfied: uncertainties>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (3.1.7)\n",
-            "Requirement already satisfied: spglib>=1.9.9.44 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (1.16.5)\n",
-            "Requirement already satisfied: palettable>=3.1.1 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (3.3.0)\n",
-            "Requirement already satisfied: tabulate in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (0.8.9)\n",
-            "Requirement already satisfied: matplotlib>=1.5 in /usr/local/lib/python3.7/dist-packages (from pymatgen>=2022.0.11->matminer) (3.2.2)\n",
-            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.5->pymatgen>=2022.0.11->matminer) (3.0.9)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.5->pymatgen>=2022.0.11->matminer) (0.11.0)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.5->pymatgen>=2022.0.11->matminer) (1.4.3)\n",
-            "Requirement already satisfied: tenacity>=6.2.0 in /usr/local/lib/python3.7/dist-packages (from plotly>=4.5.0->pymatgen>=2022.0.11->matminer) (8.0.1)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests>=2.26.0->matminer) (2.10)\n",
-            "Requirement already satisfied: charset-normalizer<3,>=2 in /usr/local/lib/python3.7/dist-packages (from requests>=2.26.0->matminer) (2.1.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.26.0->matminer) (2022.6.15)\n",
-            "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.26.0->matminer) (1.24.3)\n",
-            "Requirement already satisfied: ruamel.yaml.clib>=0.2.6 in /usr/local/lib/python3.7/dist-packages (from ruamel.yaml>=0.15.6->pymatgen>=2022.0.11->matminer) (0.2.6)\n",
-            "Requirement already satisfied: joblib>=0.11 in /usr/local/lib/python3.7/dist-packages (from scikit-learn>=0.24.2->matminer) (1.1.0)\n",
-            "Requirement already satisfied: threadpoolctl>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from scikit-learn>=0.24.2->matminer) (3.1.0)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.7/dist-packages (from sympy>=1.8->matminer) (1.2.1)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Properties associated with each entry in the JARVIS-DFT 3D materials database."
-      ],
-      "metadata": {
-        "id": "TS2aJVrfCYyN"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(dft3d_df.columns)"
-      ],
-      "metadata": {
-        "id": "sl7eZ4ltmtBB",
-        "outputId": "b9b32377-a880-436f-80df-3cacc085e29e",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Index(['epsilon_x opt', 'epsilon_y opt', 'epsilon_z opt', 'structure',\n",
-            "       'e_form', 'shear modulus', 'structure initial', 'jid', 'bulk modulus',\n",
-            "       'gap tbmbj', 'epsilon_x tbmbj', 'epsilon_y tbmbj', 'epsilon_z tbmbj',\n",
-            "       'mpid', 'gap opt', 'composition'],\n",
-            "      dtype='object')\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "'''\n",
-        "dropna(): Drop rows that contain any NaN (not a number) values.\n",
-        "'''\n",
-        "dft3d_df = dft3d_df.dropna()\n",
-        "\n",
-        "#Fetch the first 50 rows\n",
-        "dft3d_50 = dft3d_df.head(50)\n",
-        "\n",
-        "dft3d_50[:10]"
-      ],
-      "metadata": {
-        "id": "VwcZc_PLmvjw",
-        "outputId": "369b2054-5c57-433f-fb2f-9a4d0c4f0f01",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 965
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "     epsilon_x opt  epsilon_y opt  epsilon_z opt  \\\n",
-              "75         21.0673        29.1228        17.6066   \n",
-              "80         13.8023        38.1854        35.5515   \n",
-              "83          6.3933         6.9466         6.3796   \n",
-              "92          6.0838         6.0838         6.5652   \n",
-              "95          7.0316         6.3127         5.2274   \n",
-              "96          4.6738         4.7460         4.7722   \n",
-              "99          5.0636         5.0798         4.9797   \n",
-              "103         2.8447         2.9459         2.7976   \n",
-              "108         4.9033         5.1118         5.1243   \n",
-              "115        16.9750        14.0779        15.5189   \n",
-              "\n",
-              "                                             structure  e_form  shear modulus  \\\n",
-              "75   [[3.1506963  4.30596127 3.56982179] As, [0.384...   0.025         19.993   \n",
-              "80   [[0.37213617 3.67987527 0.87369073] H, [1.4889...  -1.184         25.667   \n",
-              "83   [[ 0.92796672  1.82915421 10.16747299] O, [2.7...  -2.086         52.420   \n",
-              "92   [[0. 0. 0.] Ag, [2.22040369 2.22040369 0.     ...  -0.204          5.947   \n",
-              "95   [[0.         2.06587432 0.88869064] Zr, [1.814...  -1.768         37.120   \n",
-              "96   [[1.41349448 4.71501305 5.06256213] In, [0.289...  -0.830          9.047   \n",
-              "99   [[1.50785766 1.02477434 2.93571664] Y, [ 7.555...  -1.473          7.687   \n",
-              "103  [[1.17206677 8.41802227 0.93781225] Al, [0.259...  -2.430         73.973   \n",
-              "108  [[ 2.54192839 -1.33085318 -0.81347227] Bi, [4....  -1.969         38.960   \n",
-              "115  [[-1.3982931  -1.34418681 -3.44903549] Cu, [ 0...  -0.716         43.800   \n",
-              "\n",
-              "                                     structure initial          jid  \\\n",
-              "75   [[3.17888147 4.36479751 3.69558323] As, [0.381...  JVASP-11997   \n",
-              "80   [[0.34436223 3.69323659 0.87470146] H, [1.4990...  JVASP-12002   \n",
-              "83   [[ 0.938753    1.84002706 10.93783201] O, [2.8...  JVASP-12010   \n",
-              "92   [[0. 0. 0.] Ag, [2.2945515 2.2945515 0.       ...  JVASP-12023   \n",
-              "95   [[0.         2.085838   0.88566666] Zr, [1.819...  JVASP-12027   \n",
-              "96   [[8.49448596 4.73948454 6.27818672] In, [0.290...  JVASP-12028   \n",
-              "99   [[1.646224   1.11881123 3.20510836] Y, [ 8.247...  JVASP-12033   \n",
-              "103  [[0.2515101  8.52548747 0.940367  ] Al, [0.057...  JVASP-12038   \n",
-              "108  [[ 2.58162693 -1.32106185 -0.80748743] Bi, [4....  JVASP-12051   \n",
-              "115  [[-1.3943665  -1.40808459 -3.46870699] Cu, [ 0...  JVASP-12059   \n",
-              "\n",
-              "     bulk modulus  gap tbmbj  epsilon_x tbmbj  epsilon_y tbmbj  \\\n",
-              "75         34.556     0.6495          15.0619          14.9875   \n",
-              "80         78.478     0.0083          16.5818          61.5222   \n",
-              "83         75.067     2.4642           5.2402           5.8492   \n",
-              "92         17.478     2.7025           4.5320           4.5323   \n",
-              "95         54.633     2.2441           6.0366           5.5260   \n",
-              "96         16.378     3.7113           3.6685           3.7637   \n",
-              "99         12.578     2.8863           5.5443           5.5399   \n",
-              "103       110.656     6.9515           2.4188           2.4769   \n",
-              "108        96.300     4.4734           3.6415           3.7771   \n",
-              "115        80.133     0.0117          17.6582          21.6400   \n",
-              "\n",
-              "     epsilon_z tbmbj       mpid  gap opt    composition  \n",
-              "75           12.4788     mp-158   0.0221           (As)  \n",
-              "80           53.1874   mp-24242   0.0038  (H, O, F, Cu)  \n",
-              "83            5.3897  mp-510584   1.9202        (O, Mo)  \n",
-              "92            4.9101  mp-567809   1.2599        (Ag, I)  \n",
-              "95            4.6886  mp-570157   1.8723    (Zr, Br, N)  \n",
-              "96            3.7977  mp-570219   2.3104       (In, Br)  \n",
-              "99            5.5646  mp-571442   2.6760         (Y, I)  \n",
-              "103           2.3750  mp-625055   5.1686     (Al, H, O)  \n",
-              "108           3.7842  mp-759883   2.9829     (Bi, O, F)  \n",
-              "115          18.3388  mp-996956   0.0087     (Cu, H, O)  "
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-3bb52e33-d40f-4319-8796-1c2316d145ff\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>epsilon_x opt</th>\n",
-              "      <th>epsilon_y opt</th>\n",
-              "      <th>epsilon_z opt</th>\n",
-              "      <th>structure</th>\n",
-              "      <th>e_form</th>\n",
-              "      <th>shear modulus</th>\n",
-              "      <th>structure initial</th>\n",
-              "      <th>jid</th>\n",
-              "      <th>bulk modulus</th>\n",
-              "      <th>gap tbmbj</th>\n",
-              "      <th>epsilon_x tbmbj</th>\n",
-              "      <th>epsilon_y tbmbj</th>\n",
-              "      <th>epsilon_z tbmbj</th>\n",
-              "      <th>mpid</th>\n",
-              "      <th>gap opt</th>\n",
-              "      <th>composition</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>75</th>\n",
-              "      <td>21.0673</td>\n",
-              "      <td>29.1228</td>\n",
-              "      <td>17.6066</td>\n",
-              "      <td>[[3.1506963  4.30596127 3.56982179] As, [0.384...</td>\n",
-              "      <td>0.025</td>\n",
-              "      <td>19.993</td>\n",
-              "      <td>[[3.17888147 4.36479751 3.69558323] As, [0.381...</td>\n",
-              "      <td>JVASP-11997</td>\n",
-              "      <td>34.556</td>\n",
-              "      <td>0.6495</td>\n",
-              "      <td>15.0619</td>\n",
-              "      <td>14.9875</td>\n",
-              "      <td>12.4788</td>\n",
-              "      <td>mp-158</td>\n",
-              "      <td>0.0221</td>\n",
-              "      <td>(As)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>80</th>\n",
-              "      <td>13.8023</td>\n",
-              "      <td>38.1854</td>\n",
-              "      <td>35.5515</td>\n",
-              "      <td>[[0.37213617 3.67987527 0.87369073] H, [1.4889...</td>\n",
-              "      <td>-1.184</td>\n",
-              "      <td>25.667</td>\n",
-              "      <td>[[0.34436223 3.69323659 0.87470146] H, [1.4990...</td>\n",
-              "      <td>JVASP-12002</td>\n",
-              "      <td>78.478</td>\n",
-              "      <td>0.0083</td>\n",
-              "      <td>16.5818</td>\n",
-              "      <td>61.5222</td>\n",
-              "      <td>53.1874</td>\n",
-              "      <td>mp-24242</td>\n",
-              "      <td>0.0038</td>\n",
-              "      <td>(H, O, F, Cu)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>83</th>\n",
-              "      <td>6.3933</td>\n",
-              "      <td>6.9466</td>\n",
-              "      <td>6.3796</td>\n",
-              "      <td>[[ 0.92796672  1.82915421 10.16747299] O, [2.7...</td>\n",
-              "      <td>-2.086</td>\n",
-              "      <td>52.420</td>\n",
-              "      <td>[[ 0.938753    1.84002706 10.93783201] O, [2.8...</td>\n",
-              "      <td>JVASP-12010</td>\n",
-              "      <td>75.067</td>\n",
-              "      <td>2.4642</td>\n",
-              "      <td>5.2402</td>\n",
-              "      <td>5.8492</td>\n",
-              "      <td>5.3897</td>\n",
-              "      <td>mp-510584</td>\n",
-              "      <td>1.9202</td>\n",
-              "      <td>(O, Mo)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>92</th>\n",
-              "      <td>6.0838</td>\n",
-              "      <td>6.0838</td>\n",
-              "      <td>6.5652</td>\n",
-              "      <td>[[0. 0. 0.] Ag, [2.22040369 2.22040369 0.     ...</td>\n",
-              "      <td>-0.204</td>\n",
-              "      <td>5.947</td>\n",
-              "      <td>[[0. 0. 0.] Ag, [2.2945515 2.2945515 0.       ...</td>\n",
-              "      <td>JVASP-12023</td>\n",
-              "      <td>17.478</td>\n",
-              "      <td>2.7025</td>\n",
-              "      <td>4.5320</td>\n",
-              "      <td>4.5323</td>\n",
-              "      <td>4.9101</td>\n",
-              "      <td>mp-567809</td>\n",
-              "      <td>1.2599</td>\n",
-              "      <td>(Ag, I)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>95</th>\n",
-              "      <td>7.0316</td>\n",
-              "      <td>6.3127</td>\n",
-              "      <td>5.2274</td>\n",
-              "      <td>[[0.         2.06587432 0.88869064] Zr, [1.814...</td>\n",
-              "      <td>-1.768</td>\n",
-              "      <td>37.120</td>\n",
-              "      <td>[[0.         2.085838   0.88566666] Zr, [1.819...</td>\n",
-              "      <td>JVASP-12027</td>\n",
-              "      <td>54.633</td>\n",
-              "      <td>2.2441</td>\n",
-              "      <td>6.0366</td>\n",
-              "      <td>5.5260</td>\n",
-              "      <td>4.6886</td>\n",
-              "      <td>mp-570157</td>\n",
-              "      <td>1.8723</td>\n",
-              "      <td>(Zr, Br, N)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>96</th>\n",
-              "      <td>4.6738</td>\n",
-              "      <td>4.7460</td>\n",
-              "      <td>4.7722</td>\n",
-              "      <td>[[1.41349448 4.71501305 5.06256213] In, [0.289...</td>\n",
-              "      <td>-0.830</td>\n",
-              "      <td>9.047</td>\n",
-              "      <td>[[8.49448596 4.73948454 6.27818672] In, [0.290...</td>\n",
-              "      <td>JVASP-12028</td>\n",
-              "      <td>16.378</td>\n",
-              "      <td>3.7113</td>\n",
-              "      <td>3.6685</td>\n",
-              "      <td>3.7637</td>\n",
-              "      <td>3.7977</td>\n",
-              "      <td>mp-570219</td>\n",
-              "      <td>2.3104</td>\n",
-              "      <td>(In, Br)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>99</th>\n",
-              "      <td>5.0636</td>\n",
-              "      <td>5.0798</td>\n",
-              "      <td>4.9797</td>\n",
-              "      <td>[[1.50785766 1.02477434 2.93571664] Y, [ 7.555...</td>\n",
-              "      <td>-1.473</td>\n",
-              "      <td>7.687</td>\n",
-              "      <td>[[1.646224   1.11881123 3.20510836] Y, [ 8.247...</td>\n",
-              "      <td>JVASP-12033</td>\n",
-              "      <td>12.578</td>\n",
-              "      <td>2.8863</td>\n",
-              "      <td>5.5443</td>\n",
-              "      <td>5.5399</td>\n",
-              "      <td>5.5646</td>\n",
-              "      <td>mp-571442</td>\n",
-              "      <td>2.6760</td>\n",
-              "      <td>(Y, I)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>103</th>\n",
-              "      <td>2.8447</td>\n",
-              "      <td>2.9459</td>\n",
-              "      <td>2.7976</td>\n",
-              "      <td>[[1.17206677 8.41802227 0.93781225] Al, [0.259...</td>\n",
-              "      <td>-2.430</td>\n",
-              "      <td>73.973</td>\n",
-              "      <td>[[0.2515101  8.52548747 0.940367  ] Al, [0.057...</td>\n",
-              "      <td>JVASP-12038</td>\n",
-              "      <td>110.656</td>\n",
-              "      <td>6.9515</td>\n",
-              "      <td>2.4188</td>\n",
-              "      <td>2.4769</td>\n",
-              "      <td>2.3750</td>\n",
-              "      <td>mp-625055</td>\n",
-              "      <td>5.1686</td>\n",
-              "      <td>(Al, H, O)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>108</th>\n",
-              "      <td>4.9033</td>\n",
-              "      <td>5.1118</td>\n",
-              "      <td>5.1243</td>\n",
-              "      <td>[[ 2.54192839 -1.33085318 -0.81347227] Bi, [4....</td>\n",
-              "      <td>-1.969</td>\n",
-              "      <td>38.960</td>\n",
-              "      <td>[[ 2.58162693 -1.32106185 -0.80748743] Bi, [4....</td>\n",
-              "      <td>JVASP-12051</td>\n",
-              "      <td>96.300</td>\n",
-              "      <td>4.4734</td>\n",
-              "      <td>3.6415</td>\n",
-              "      <td>3.7771</td>\n",
-              "      <td>3.7842</td>\n",
-              "      <td>mp-759883</td>\n",
-              "      <td>2.9829</td>\n",
-              "      <td>(Bi, O, F)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>115</th>\n",
-              "      <td>16.9750</td>\n",
-              "      <td>14.0779</td>\n",
-              "      <td>15.5189</td>\n",
-              "      <td>[[-1.3982931  -1.34418681 -3.44903549] Cu, [ 0...</td>\n",
-              "      <td>-0.716</td>\n",
-              "      <td>43.800</td>\n",
-              "      <td>[[-1.3943665  -1.40808459 -3.46870699] Cu, [ 0...</td>\n",
-              "      <td>JVASP-12059</td>\n",
-              "      <td>80.133</td>\n",
-              "      <td>0.0117</td>\n",
-              "      <td>17.6582</td>\n",
-              "      <td>21.6400</td>\n",
-              "      <td>18.3388</td>\n",
-              "      <td>mp-996956</td>\n",
-              "      <td>0.0087</td>\n",
-              "      <td>(Cu, H, O)</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3bb52e33-d40f-4319-8796-1c2316d145ff')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-3bb52e33-d40f-4319-8796-1c2316d145ff button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-3bb52e33-d40f-4319-8796-1c2316d145ff');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 3
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Here, we print out all the compositions in our select dataset of 50 materials."
-      ],
-      "metadata": {
-        "id": "c-_0VEWkCnwh"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install -U jarvis-tools"
-      ],
-      "metadata": {
-        "id": "gqFLu2zidKEU",
-        "collapsed": true,
-        "outputId": "da764e75-41a1-41fe-9d7f-e2ef7d9228e1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting jarvis-tools\n",
-            "  Downloading jarvis_tools-2022.5.20-py2.py3-none-any.whl (962 kB)\n",
-            "\u001b[?25l\r\u001b[K     |▍                               | 10 kB 16.4 MB/s eta 0:00:01\r\u001b[K     |▊                               | 20 kB 20.2 MB/s eta 0:00:01\r\u001b[K     |█                               | 30 kB 22.7 MB/s eta 0:00:01\r\u001b[K     |█▍                              | 40 kB 14.3 MB/s eta 0:00:01\r\u001b[K     |█▊                              | 51 kB 11.7 MB/s eta 0:00:01\r\u001b[K     |██                              | 61 kB 13.4 MB/s eta 0:00:01\r\u001b[K     |██▍                             | 71 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |██▊                             | 81 kB 11.8 MB/s eta 0:00:01\r\u001b[K     |███                             | 92 kB 12.9 MB/s eta 0:00:01\r\u001b[K     |███▍                            | 102 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███▊                            | 112 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████                            | 122 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████▍                           | 133 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████▊                           | 143 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████                           | 153 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████▌                          | 163 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████▉                          | 174 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████▏                         | 184 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████▌                         | 194 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████▉                         | 204 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████▏                        | 215 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████▌                        | 225 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████▉                        | 235 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████▏                       | 245 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████▌                       | 256 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████▉                       | 266 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████▏                      | 276 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████▌                      | 286 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████▉                      | 296 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████▏                     | 307 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████▋                     | 317 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████                     | 327 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████▎                    | 337 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████▋                    | 348 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████                    | 358 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████▎                   | 368 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████▋                   | 378 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 389 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████▎                  | 399 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████▋                  | 409 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████                  | 419 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████▎                 | 430 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████▋                 | 440 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████                 | 450 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████▎                | 460 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████▋                | 471 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████                | 481 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████▍               | 491 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████▊               | 501 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████               | 512 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████▍              | 522 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████▊              | 532 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████              | 542 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████▍             | 552 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████▊             | 563 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████             | 573 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████▍            | 583 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████▊            | 593 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████            | 604 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████▍           | 614 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████▊           | 624 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▏          | 634 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▌          | 645 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▉          | 655 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████▏         | 665 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████▌         | 675 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████▉         | 686 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▏        | 696 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▌        | 706 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████▉        | 716 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████▏       | 727 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████▌       | 737 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████▉       | 747 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▏      | 757 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▌      | 768 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▉      | 778 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▏     | 788 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▋     | 798 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████     | 808 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▎    | 819 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▋    | 829 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████    | 839 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▎   | 849 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▋   | 860 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████   | 870 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▎  | 880 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▋  | 890 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████  | 901 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▎ | 911 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▋ | 921 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████ | 931 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▎| 942 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████▊| 952 kB 12.6 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 962 kB 12.6 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: scipy>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (1.7.3)\n",
-            "Requirement already satisfied: spglib>=1.14.1 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (1.16.5)\n",
-            "Requirement already satisfied: tqdm>=4.41.1 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (4.64.0)\n",
-            "Requirement already satisfied: toolz>=0.9.0 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (0.11.2)\n",
-            "Collecting xmltodict>=0.11.0\n",
-            "  Downloading xmltodict-0.13.0-py2.py3-none-any.whl (10.0 kB)\n",
-            "Requirement already satisfied: requests>=2.23.0 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (2.28.1)\n",
-            "Requirement already satisfied: numpy>=1.19.5 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (1.21.6)\n",
-            "Requirement already satisfied: matplotlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (3.2.2)\n",
-            "Requirement already satisfied: joblib>=0.14.1 in /usr/local/lib/python3.7/dist-packages (from jarvis-tools) (1.1.0)\n",
-            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=3.0.0->jarvis-tools) (0.11.0)\n",
-            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=3.0.0->jarvis-tools) (3.0.9)\n",
-            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=3.0.0->jarvis-tools) (1.4.3)\n",
-            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=3.0.0->jarvis-tools) (2.8.2)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from kiwisolver>=1.0.1->matplotlib>=3.0.0->jarvis-tools) (4.1.1)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.1->matplotlib>=3.0.0->jarvis-tools) (1.16.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.23.0->jarvis-tools) (2022.6.15)\n",
-            "Requirement already satisfied: charset-normalizer<3,>=2 in /usr/local/lib/python3.7/dist-packages (from requests>=2.23.0->jarvis-tools) (2.1.0)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests>=2.23.0->jarvis-tools) (2.10)\n",
-            "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.23.0->jarvis-tools) (1.24.3)\n",
-            "Installing collected packages: xmltodict, jarvis-tools\n",
-            "Successfully installed jarvis-tools-2022.5.20 xmltodict-0.13.0\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from jarvis.db.figshare import data\n",
-        "from jarvis.core.atoms import Atoms\n",
-        "\n",
-        "dft_3d = data(\"dft_3d\")\n",
-        "\n",
-        "comp_list = []\n",
-        "for indx, d in dft3d_50.iterrows():\n",
-        "  entry = next(j for j in dft_3d if j[\"jid\"] == d[\"jid\"])\n",
-        "  comp = Atoms.from_dict(entry['atoms']).composition.reduced_formula\n",
-        "  comp_list.append(comp)\n",
-        "\n",
-        "print(comp_list)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "js-QUJt4f2gn",
-        "outputId": "01a7c3a2-ee6a-4a91-ce52-ebad6d5899b7"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Obtaining 3D dataset 55k ...\n",
-            "Reference:https://www.nature.com/articles/s41524-020-00440-1\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 31.9M/31.9M [00:01<00:00, 17.6MiB/s]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Loading the zipfile...\n",
-            "Loading completed.\n",
-            "['As', 'CuHOF', 'MoO3', 'AgI', 'ZrBrN', 'InBr3', 'YI3', 'AlHO2', 'BiOF', 'CuHO2', 'TiClO', 'VCuO4', 'ScBrO', 'ZnCu3H6Cl2O6', 'VOF3', 'ZnCl2', 'ScHO2', 'ZrMo2O8', 'BaCaI4', 'CaPbI4', 'YBr3', 'NdIO', 'Li2WS4', 'SnO2', 'SnO2', 'CoF2', 'GaS', 'RbPS3', 'BeF2', 'BeO', 'CO2', 'CaCl2', 'SrClF', 'SrBrF', 'SrCl2', 'CaCl2', 'CaClF', 'NaHF2', 'Bi2SO2', 'BrF5', 'IF7', 'AsF3', 'KSc2F7', 'CClF3', 'K2MgF4', 'LiMgP', 'H4BrN', 'NaHS', 'SrAl2Te4', 'AgAsF6']\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Here, we filter out the feature vector to only include single scalar-values properties."
-      ],
-      "metadata": {
-        "id": "EACr0qhNDQ51"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#Form feature vector from the scalar properties in the dataframe\n",
-        "scalar_cols = [col for col in dft3d_50.columns if col not in ['structure', 'structure initial', 'jid', 'mpid', 'composition']]\n",
-        "\n",
-        "feature_vect = dft3d_50[scalar_cols].to_numpy()\n",
-        "\n",
-        "feature_vect[:10]"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "FsH2HKwWCEe0",
-        "outputId": "d23135e0-8c6c-467f-e5e3-a0d005efb555"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "array([[ 2.10673e+01,  2.91228e+01,  1.76066e+01,  2.50000e-02,\n",
-              "         1.99930e+01,  3.45560e+01,  6.49500e-01,  1.50619e+01,\n",
-              "         1.49875e+01,  1.24788e+01,  2.21000e-02],\n",
-              "       [ 1.38023e+01,  3.81854e+01,  3.55515e+01, -1.18400e+00,\n",
-              "         2.56670e+01,  7.84780e+01,  8.30000e-03,  1.65818e+01,\n",
-              "         6.15222e+01,  5.31874e+01,  3.80000e-03],\n",
-              "       [ 6.39330e+00,  6.94660e+00,  6.37960e+00, -2.08600e+00,\n",
-              "         5.24200e+01,  7.50670e+01,  2.46420e+00,  5.24020e+00,\n",
-              "         5.84920e+00,  5.38970e+00,  1.92020e+00],\n",
-              "       [ 6.08380e+00,  6.08380e+00,  6.56520e+00, -2.04000e-01,\n",
-              "         5.94700e+00,  1.74780e+01,  2.70250e+00,  4.53200e+00,\n",
-              "         4.53230e+00,  4.91010e+00,  1.25990e+00],\n",
-              "       [ 7.03160e+00,  6.31270e+00,  5.22740e+00, -1.76800e+00,\n",
-              "         3.71200e+01,  5.46330e+01,  2.24410e+00,  6.03660e+00,\n",
-              "         5.52600e+00,  4.68860e+00,  1.87230e+00],\n",
-              "       [ 4.67380e+00,  4.74600e+00,  4.77220e+00, -8.30000e-01,\n",
-              "         9.04700e+00,  1.63780e+01,  3.71130e+00,  3.66850e+00,\n",
-              "         3.76370e+00,  3.79770e+00,  2.31040e+00],\n",
-              "       [ 5.06360e+00,  5.07980e+00,  4.97970e+00, -1.47300e+00,\n",
-              "         7.68700e+00,  1.25780e+01,  2.88630e+00,  5.54430e+00,\n",
-              "         5.53990e+00,  5.56460e+00,  2.67600e+00],\n",
-              "       [ 2.84470e+00,  2.94590e+00,  2.79760e+00, -2.43000e+00,\n",
-              "         7.39730e+01,  1.10656e+02,  6.95150e+00,  2.41880e+00,\n",
-              "         2.47690e+00,  2.37500e+00,  5.16860e+00],\n",
-              "       [ 4.90330e+00,  5.11180e+00,  5.12430e+00, -1.96900e+00,\n",
-              "         3.89600e+01,  9.63000e+01,  4.47340e+00,  3.64150e+00,\n",
-              "         3.77710e+00,  3.78420e+00,  2.98290e+00],\n",
-              "       [ 1.69750e+01,  1.40779e+01,  1.55189e+01, -7.16000e-01,\n",
-              "         4.38000e+01,  8.01330e+01,  1.17000e-02,  1.76582e+01,\n",
-              "         2.16400e+01,  1.83388e+01,  8.70000e-03]])"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 13
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Machine Learning Models Implemented in Sci-kit Learn\n",
-        "\n",
-        "``sci-kit learn`` is a Python package that faciliates the implementation of several machine learning models for dimensionality reduction, clustering, classification, regression, and more."
-      ],
-      "metadata": {
-        "id": "svC874oHDb5w"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install -U scikit-learn"
-      ],
-      "metadata": {
-        "id": "ZaGVRxi0o6Ko",
-        "outputId": "5ee4bfbe-c74c-4e1f-aa77-e2322ace2a91",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (1.0.2)\n",
-            "Requirement already satisfied: scipy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from scikit-learn) (1.7.3)\n",
-            "Requirement already satisfied: numpy>=1.14.6 in /usr/local/lib/python3.7/dist-packages (from scikit-learn) (1.21.6)\n",
-            "Requirement already satisfied: joblib>=0.11 in /usr/local/lib/python3.7/dist-packages (from scikit-learn) (1.1.0)\n",
-            "Requirement already satisfied: threadpoolctl>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from scikit-learn) (3.1.0)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Before performing K-means clustering, the data is pre-processed such that each feature has a mean centered at zero and a standard deviation of 1.\n",
-        "\n",
-        "**Try modifying**\n",
-        "\n",
-        "Run the K--means clustering on the un-scaled feature vector ``feature_vect`` instead to see what happens"
-      ],
-      "metadata": {
-        "id": "svLOsMPEW00E"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from sklearn.cluster import KMeans\n",
-        "from sklearn import preprocessing as pp\n",
-        "\n",
-        "'''\n",
-        "Scale feature vector: pre-processing step such that features have zero mean and \n",
-        "unit variance\n",
-        "''' \n",
-        "scaler = pp.StandardScaler().fit(feature_vect)\n",
-        "\n",
-        "feat_vec_scale = scaler.transform(feature_vect)\n",
-        "\n",
-        "print('mean: ', feat_vec_scale.mean(axis=0))\n",
-        "print('std. deviation: ', feat_vec_scale.std(axis=0))"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "U256lcmBX4lN",
-        "outputId": "b420f1e8-8a1d-4bd4-85e5-dc011db7d504"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "mean:  [-1.33226763e-17  5.44009282e-17  1.47659662e-16  7.75768338e-17\n",
-            "  2.04281037e-16  3.33066907e-18  1.84297022e-16 -2.77555756e-17\n",
-            " -5.10702591e-17 -3.88578059e-17  1.53210777e-16]\n",
-            "std. deviation:  [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Run the K-means clustering and output the cluster labels for each sample in the dataset.\n",
-        "\n",
-        "**Try modifiying**\n",
-        "\n",
-        "Change the number of cluster! ``K``"
-      ],
-      "metadata": {
-        "id": "zbl03YqbYirE"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#Fit K-means model\n",
-        "\n",
-        "K = 5; #CHANGE the number of clusters generated\n",
-        "kmeans = KMeans(n_clusters=K).fit(feat_vec_scale) #CHANGE to the unscaled/un-whitened feature_vect to see what happens!\n",
-        "lbl = kmeans.labels_\n",
-        "centers = kmeans.cluster_centers_\n",
-        "y_kmeans = kmeans.predict(feat_vec_scale)\n",
-        "print(y_kmeans)"
-      ],
-      "metadata": {
-        "id": "XtbGanGNpSAY",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c6f40e63-2eec-474d-8702-2aabaefa8906"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[4 4 3 3 3 3 3 1 3 4 4 4 1 4 3 3 1 3 3 3 3 1 3 3 3 2 3 3 1 0 1 1 1 1 1 1 1\n",
-            " 1 3 3 3 1 1 1 1 3 3 3 3 3]\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#Print contents of each cluster\n",
-        "import numpy as np\n",
-        "\n",
-        "for k in range(K): #For each generated cluster\n",
-        "    pos= [n for (n,m) in enumerate(lbl) if m==k] #Get the indices in the labels vector which point ot that cluster\n",
-        "    compGrp = np.array(comp_list)[pos]\n",
-        "    print('Generated Compound Cluster #{}'.format(k+1))\n",
-        "    print(compGrp)\n",
-        "    print('mean feature values of the cluster:')\n",
-        "    print([{f:m} for f,m in zip(scalar_cols, centers[k])])\n",
-        "    print('\\n')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7QFv4XsNS7kb",
-        "outputId": "26715837-b738-485e-d51f-1d5fb8a45af2"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Generated Compound Cluster #1\n",
-            "['BeO']\n",
-            "mean feature values of the cluster:\n",
-            "[{'epsilon_x opt': -0.4985765556070252}, {'epsilon_y opt': -0.44352794159575876}, {'epsilon_z opt': -0.39722621949893017}, {'e_form': -1.2505278304491392}, {'shear modulus': 5.250759493766172}, {'bulk modulus': 3.970117173766432}, {'gap tbmbj': 1.506400920957915}, {'epsilon_x tbmbj': -0.4353848207716034}, {'epsilon_y tbmbj': -0.35218821306543263}, {'epsilon_z tbmbj': -0.2954181626154681}, {'gap opt': 1.7572691120259651}]\n",
-            "\n",
-            "\n",
-            "Generated Compound Cluster #2\n",
-            "['AlHO2' 'ScBrO' 'ScHO2' 'NdIO' 'BeF2' 'CO2' 'CaCl2' 'SrClF' 'SrBrF'\n",
-            " 'SrCl2' 'CaCl2' 'CaClF' 'NaHF2' 'AsF3' 'KSc2F7' 'CClF3' 'K2MgF4']\n",
-            "mean feature values of the cluster:\n",
-            "[{'epsilon_x opt': -0.49856046466816817}, {'epsilon_y opt': -0.44987579963068974}, {'epsilon_z opt': -0.40449841660578467}, {'e_form': -0.9600209024705456}, {'shear modulus': -0.0472778785120525}, {'bulk modulus': -0.06203775122462261}, {'gap tbmbj': 1.028887385213975}, {'epsilon_x tbmbj': -0.4384430194885642}, {'epsilon_y tbmbj': -0.35688308637197885}, {'epsilon_z tbmbj': -0.29937843629234284}, {'gap opt': 1.0672560059995477}]\n",
-            "\n",
-            "\n",
-            "Generated Compound Cluster #3\n",
-            "['CoF2']\n",
-            "mean feature values of the cluster:\n",
-            "[{'epsilon_x opt': 5.118080483232208}, {'epsilon_y opt': 5.176294061860992}, {'epsilon_z opt': 5.821624635010576}, {'e_form': 0.24850991676223486}, {'shear modulus': 0.6453762819050016}, {'bulk modulus': 2.169974828558438}, {'gap tbmbj': -1.4111669293016793}, {'epsilon_x tbmbj': 4.325172905340975}, {'epsilon_y tbmbj': 5.546947827501139}, {'epsilon_z tbmbj': 6.202183200667313}, {'gap opt': -1.3897437533069272}]\n",
-            "\n",
-            "\n",
-            "Generated Compound Cluster #4\n",
-            "['MoO3' 'AgI' 'ZrBrN' 'InBr3' 'YI3' 'BiOF' 'VOF3' 'ZnCl2' 'ZrMo2O8'\n",
-            " 'BaCaI4' 'CaPbI4' 'YBr3' 'Li2WS4' 'SnO2' 'SnO2' 'GaS' 'RbPS3' 'Bi2SO2'\n",
-            " 'BrF5' 'IF7' 'LiMgP' 'H4BrN' 'NaHS' 'SrAl2Te4' 'AgAsF6']\n",
-            "mean feature values of the cluster:\n",
-            "[{'epsilon_x opt': -0.21682222679516291}, {'epsilon_y opt': -0.23587457661443534}, {'epsilon_z opt': -0.16805750265177455}, {'e_form': 0.5233023387250574}, {'shear modulus': -0.2717191062119349}, {'bulk modulus': -0.30732137643418195}, {'gap tbmbj': -0.3734596970308861}, {'epsilon_x tbmbj': -0.2512046137285392}, {'epsilon_y tbmbj': -0.2548553906640444}, {'epsilon_z tbmbj': -0.19708268826991868}, {'gap opt': -0.4074735795047337}]\n",
-            "\n",
-            "\n",
-            "Generated Compound Cluster #5\n",
-            "['As' 'CuHOF' 'CuHO2' 'TiClO' 'VCuO4' 'ZnCu3H6Cl2O6']\n",
-            "mean feature values of the cluster:\n",
-            "[{'epsilon_x opt': 1.5460966069354574}, {'epsilon_y opt': 1.4686644814695633}, {'epsilon_z opt': 0.9422520388468436}, {'e_form': 0.7066357979266257}, {'shear modulus': 0.28342763572201696}, {'bulk modulus': 0.43293069655804395}, {'gap tbmbj': -1.3749711857536084}, {'epsilon_x tbmbj': 1.6406430983249498}, {'epsilon_y tbmbj': 1.2072729367481736}, {'epsilon_z tbmbj': 0.6849559309443248}, {'gap opt': -1.387339662182166}]\n",
-            "\n",
-            "\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Here, we will use principal component analysis (PCA) primarily as a way to visualize our \"high-dimensional\" data (11 total features) in two dimensions. \n",
-        "\n",
-        "**Try modifying**\n",
-        "\n",
-        "Perform the PCA on the feeature vector first and then apply the K-means clustering algorithm to the principal component vectors."
-      ],
-      "metadata": {
-        "id": "XW_F_bvfY4mL"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Plot samples against first two principal components, colored by their cluster\n",
-        "import matplotlib.pyplot as plt\n",
-        "%matplotlib inline\n",
-        "from sklearn.decomposition import PCA\n",
-        "pca = PCA(n_components = 2)\n",
-        "pca.fit(feat_vec_scale)\n",
-        "print(pca)\n",
-        "comp_dim = pca.transform(feat_vec_scale)\n",
-        "plt.figure()\n",
-        "plt.scatter(comp_dim[:,0], comp_dim[:,1], c=y_kmeans) \n",
-        "plt.xlabel('Principal Component 1')\n",
-        "plt.ylabel('Principal Component 2')\n",
-        "plt.show()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 297
-        },
-        "id": "HSYvic0kvyXA",
-        "outputId": "7480cd03-d894-47a2-de1e-842898f6270d"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "PCA(n_components=2)\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxU5dn/8c81S3YgYAJhX5XFHRBFXKu17lYfl1rrUqvoo6211dra1l/t08e2Vqu21tb6uLV1q7VacUMREREXFtlkFRAEBcKefbZz/f6YCSZkJpkkM3MmzPV+vfJK5szJnO9EPNec+77PfYuqYowxJvd43A5gjDHGHVYAjDEmR1kBMMaYHGUFwBhjcpQVAGOMyVE+twO0R1lZmQ4ZMsTtGMYY06XMnz9/m6qW7729SxWAIUOGMG/ePLdjGGNMlyIi6+NttyYgY4zJUVYAjDEmR1kBMMaYHGUFwBhjcpQVgAyo2lHN4neWsWntFrejGGPMHl1qFFBXo6o8+rOneP6+V/Dn+wkFw4w56gBuf/5minsUux3PGJPj7Aogjd584h3+88fXCDaEqN1dR7A+yNLZK7jz8j+5Hc0YY6wApNO/fj+FhrpAs22hYJh5ry+kZletS6mMMSbKCkAaVW+vibvd4/VQu7suw2mMMaY5KwBpNO6UQ/F4W/6Ji7oVUj5wPxcSGWPMl6wApNFlt19IcWkR/rxoX7uIkF+Ux40PXoPHY396Y4y7bBRQGvUeWMbDS+7huXteZvHMpfQdXsEFN53FAeOGux3NGGOsAKRbr4qeTP7dpW7HMMaYFqwdwhhjcpSrBUBESkXkORFZISLLRWSim3mMMSaXuN0E9AdgqqqeLyJ5QJHLeYwxJme4VgBEpAdwHHAFgKoGgaBbeYwxJte42QQ0FNgKPCYiC0TkYRFpMUGOiEwWkXkiMm/r1q2ZT2mMMfsoNwuADxgL/EVVDwdqgZ/svZOqPqSq41V1fHl5iyUtjTHGdJCbBWAjsFFVP4w9fo5oQTDGGJMBrhUAVd0MbBCRkbFNJwHL3MpjjDG5xu1RQN8DnoyNAFoLfNvlPMYYkzNcLQCquhAY72YGY4zJVXYnsDHG5CgrAMYYk6OsABhjTI6yAmCMMTnKCoAxxuQoKwDGGJOjrAAYY0yOsgJgjDE5ygqAMcbkKCsAxhiTo6wAGGNMjrICYIwxOcoKgDHG5CgrAMYYk6OsABhjTI6yAmCMMTnKCoAxxuQoKwDGGJOjrAAYY0yOsgJgjDE5ygqAMcbkKCsAxhiTo6wAGGNMjrICYIwxOcoKgDHG5CgrAMYYk6OsABhjTI6yAmCMMTnKCoAxxuQoKwDGGJOjEhYAETlYRD4QkQ0i8pCI9Gzy3JzMxDPGGJMurV0B/AW4HTgYWAW8KyLDY8/505zLGGNMmvlaea6bqk6N/Xy3iMwHporIpYCmP5oxxph0aq0AICI9VHU3gKrOEJH/Av4N9MpEOGOMMenTWhPQncDophtUdTFwEvB8OkMZY4xJv4RXAKr6VILtnwFXpy2RMcaYjLBhoMYYk6NcLwAi4hWRBSLysttZjDEml7RZAERkUjLbOuH7wPIUvp4xxpgkJHMFcH+S29pNRAYAZwAPp+L1jDHGJC9hJ7CITASOBspF5IdNnuoOeFN0/PuAW4BureSYDEwGGDRoUIoOa4wxprUrgDyghGiR6Nbkqwo4v7MHFpEzgUpVnd/afqr6kKqOV9Xx5eXlnT2sMcaYmNaGgc4EZorI46q6Pg3HngScLSKnAwVAdxF5QlW/lYZjGWOM2UurdwLH5IvIQ8CQpvur6lc6c2BVvRW4FUBETgButpO/McZkTjIF4F/Ag0Q7aiPpjWOMMSZTkikAYVX9SzpDqOrbwNvpPIYxxpjmkhkG+pKIXCcifUWkV+NX2pMZY4xJq2SuAC6Pff9Rk20KDEt9HGOMMZnSZgFQ1aGZCGKMMSazkpkKokhEfh4bCYSI7B8bw2+MMaYLS6YP4DEgSPSuYIDPgf9NWyJjjDEZkUwBGK6qvwNCAKpaB0haUxljjEm7ZApAUEQKia0DHFsYPpDWVMYYY9IumVFAvwCmAgNF5EmiUzhckc5Qxhhj0i+ZUUDTROQj4CiiTT/fV9VtaU9mjDEmrZK5AoDoZG07Y/uPERFU9Z30xTLGGJNubRYAEbkTuAhYCjixzQpYATDGmC4smSuArwMjVdU6fo0xZh+SzCigtYA/3UGMMcZkVjJXAHXAQhGZTpPhn6p6Q9pSGWOMSbtkCsCU2Jcxxph9SDLDQP8mInnAAbFNK1U1lN5Yxhhj0i2ZUUAnAH8D1hG9D2CgiFxuw0CNMaZrS6YJ6PfAKaq6EkBEDgCeBsalM5gxxpj0SmYUkL/x5A+gqquwUUHGGNPlJXMFME9EHgaeiD2+BJiXvkjGGGMyIZkC8N/A9UDjsM9ZwJ/TlsgYY0xGJDMKKCAifwKmE50KYqWqBtOezBhjTFolMwroDOBBYA3RUUBDReQaVX0t3eGMMcakT7KjgE5U1dWwZ0GYVwArAMYYk0ZVgQDPL1/K4i2bGV1WzvljDqJnYWHKXj+ZAlDdePKPWQtUpyyBMcaYFj6vruLrzzxBXShEfTjM1DWf8Od5H/LcBRczvNd+KTlGMsNA54nIqyJyhYhcDrwEzBWR80TkvJSkMMYY08yvZs5gZ30D9eEwAA3hMFWBAD+f8WbKjpHMFUABsAU4PvZ4K1AInEV0XYDnU5bGGGMMADPXr8OJLsW+hwJzv/iciOPg9STz+b11yYwC+nanj2KMMaZd8rweApGW270iiEhKjpHMKKChwPeAIU33V9WzU5LAGGNMC+eNOpCnly4mGPmyCvg9Hk7f/wA8mSoAwH+AR4i2/Ttt7GuaiEQc5ixax6q1lfTt3Z3jj9yf/HybRcMY07YfTTqWpdsqWVpZSeP5fmhpT355wkkpO4aoaus7iHyoqkem7IidMH78eJ03r2vMQlFXH+T6255h46adNARCFOT7Kcj38+Cvv0n/ilK34xljugBVZXHlFlZt38awnj0ZW9GvQ80/IjJfVcfvvT2ZXoQ/iMgvRGSiiIxt/Gp3ghzz2LPvsX7jduobQqhCfUOIXVX1/OqPr7odzRjTRYgIh/ap4IIxBzGub/+Utf03SqYJ6GDgUuArfNkEpLHHJoE3Zi0nGGreg6OqrFi9mZraACXF+S4lM8aYqGQKwAXAMJv/50uRiMO8xevZtrOGMfv3ZejAshb7tNW0ZowxbkumAHwMlAKVac7SJWyq3M13b3uG6toAjuOgCpPGD+cXN56B1/tli9opx47m31MXEmpyFSAijBzep9mnf1VlyrTFPP3iXKpqGjj8wIFc861jGdSvV0bflzEm9yTTB1AKrBCR10VkSuNXuoNlq5/fNYWtO2qoqw/SEAgTCIZ5b/4apkxb3Gy/Ky+axKB+vSgs8CNAYYGfHt0KuO2G05vt9+e/z+T+x2ewcfMuqmoaeGfOaq6+5Qk2V+7O4LsyxuSiZK4AfpH2FF3E1u3VfLphG47TvHmnIRDmhdcXcu6ph+3ZVlSYx6N3XcoHCz7lk08rqSjvzgkTD6CgyTDQqpoG/v3agmZ9BapKIBjmqSlz+eFVJ6f/TRljclYydwLPFJE+wBGxTXNUtdPNQSIyEPg70Idop/JDqvqHzr5uOgVDkYS98IFguMU2r9fDpPHDmTR+eNzfWb9xO36/t0VncTjisGT5F50PbIwxrWizCUhELgTmEO0MvhD4UETOT8Gxw8BNqjoGOAq4XkTGpOB106Zfnx706N5yKtY8v5eTJo1s9+tVlHdv1kfQSAQG9e/ZoYzGGJOsZPoAfgYcoaqXq+plwATgts4eWFU3qepHsZ+rgeVA/86+bjqJCL/4/hkU5Pvx+7wAFOb76du7B5d8fUK7X698v25MOGwIeX5vs+15fh/f7MDrGWNMeyRzJ/ASVT24yWMPsKjptk6HEBkCvAMcpKpVifbLljuBt26v5uXpS9hUuZvDDxrEV44eSX5eMt0pLTUEQtz90DTemr0SVehVWsTNk7/KxHHDUpzaGJOrEt0JnEwBuAs4BHg6tukiYImq3pKiYCXATOAOVW0xtbSITAYmAwwaNGjc+vXrU3HYrBMIhKhrCFHavTDld/sZY3JbhwtA7JfPA46JPZylqi+kKJQfeBl4XVXvaWv/dF8BbK7czZbt1QwdWEb3koK0HccYYzIpUQFI2G4hIiOAPqo6O/bJ/PnY9mNEZLiqrulkICE6y+jyZE7+6VRbF+Dnd09h0bKN+P1eQqEIF545jmsuOdY+jRtj9lmtdQLfB8Rrj98de66zJhGbY0hEFsa+Tm/rl9ojEnH450vzuPC6/+OsK//Mbx6YyrYdNS32+/UDU1m4dCPBUITauiDBUITnXv2I12cuS2UcY4zJKq31XPZR1SV7b1TVJbFO205R1XeBtH68/s2fpzLj/VUEAtEx+lNnLuX9j9byxB+u3NPEU1Mb4L15awmFmw/HbAiEeerFuZx6woHpjGiMMa5p7QqgtUnrWw6GzzKbKnfz1uyVe07+AJGIUlsX5KU3v5y2oaYugMcTvw7trq5Pe05jjHFLawVgnohcvfdGEbkKmJ++SKmxau2WPWP1mwoEwyxYumHP4977daO4KK/Ffh6PMP6QwWnNaIwxbmqtCehG4AURuYQvT/jjgTzg3HQH66yK3j2IOC1HOPm8HgY3mWnT4xF+dM0p3H7vywRDYVTB5/NQWJDH1d+YlMnIxhiTUQkLgKpuAY4WkROBg2KbX1HVtzKSrJMOGNqbwf17sWb9VsKRL5cy9vm8nHfa4c32PXbCCB741Td46sU5bNy8i8MPHMjFZx9BWa+STMc2xpiMSeo+gGzR3vsAdlfX87/3v8bcResQEcp7lfDT60/lsAMHdirHzt21bPhiJyvXbOHfUxeyY1cto0dUcN1lxzNyWJ9OvbYxxqRap24EyxYdvRGsti5AIBimZ4+iTo3rD0ccfveXN3jz3eWoKqGw0+z5gnwfD/76EkYMKe/wMYwxJtU6syh8l1dclE+v0uJO39T12LPvMX32CoKhSIuTP0Q7mB99dnanjmGMMZmSEwUgVZ5/bUHcef8bqcLKNVsymMgYYzqutakgqoku1NLiKUBVtXvaUmWp2vpgm/v0r2jt9gljjMkerY0C6pbJIF3BqOEVLPtkU8Ln8/N8XHHBxAwmMsaYjku6CUhEeovIoMavdIbKVj+46isU5Pvx7nXnsNfrobxXCbfdcDpjD8rJP40xpgtqcxUTETkb+D3QD6gEBhNdvSvnJskZPaIvj951KU+88CGrPq1k/6G9+cZZ4+ld1o2SonybOdQY06Uks4zVr4iu2fumqh4euzHsW+mNlb0G9e/FT797mtsxjDGm05JpAgqp6nbAIyIeVZ1BdEoIY4wxXVgyVwC7Yss2zgKeFJFKoDa9sboOVeW9+Wt5ZfoSIo5yynGjOXHiyIQzjBpjTLZIpgCcAzQQnRzuEqAH8D/pDNWV3P3Xabz+znIaAiEA5i/5jLdmr+R/f3S29QkYY7Jam01AqloLlAOnAzuAZ2NNQjlv7WdbmTpz2Z6TP0BDIMSHC9exaNlGF5MZY0zb2iwAsfn/5wDnAecDH4jIlekOlik1tQGWr97Ejl3tb9Wat/gznDhTTjcEQnywcF0K0hljTPok0wT0I+Dwxk/9IrIf8B7waDqDpZuq8tcnZ/HsKx/h93kIhSIcPX44t33vNPLz/Um9RklRPl6vp8Vyknl+L92L89MR2xhjUiaZUUDbgeomj6tj27q0KdMW89yrHxEMhvcsBP/evDXc+0jyyx0cd+T+xGvmFxG+euzolGXdFdzFP9Y/yS2Lfsody37LvB0fsbp6NauqPyHsJJ6bqCtRdXBqn8bZdibO1pNwqu9GnSq3YxmzT2tzOmgR+TtwMPAi0bmBzgEWx75Q1XvSnHGPjk4HHc9F1z/M55t3tdie5/cy9R/fI8+fzMURLFi6gVvv/A+Oo4iAOvD/bjyDY44Y3ql8gUiAtypn8O6299lU/wUKODRZ2EZ8+MSHV7xcP+JaDuwxplPHc5uz60fQ8AbQuA5zHnj7ImVTEMn6JaiNyWqJpoNO5iy3JvbV6MXY9y49V1BVggXfHVXqG0JJF4DDDxzIy49ex+LlnxNxHA4ZPYD8vOR+N5GwE+aO5XeyqX4TQY0/AV1Yw4Q1+un/vk/u5/eH3kl3f9ecn0/D66BhKhBosjUIkUqofxmKLnApmTH7tjbPVKr6y0wEybRDRg/gvflr2PsCaL/SYrqXFLTrtXw+L2MPTt0cQPN2zmdzw+aEJ/+9qSofbJ/DKRUnpyxDRoUWgXjjzD1bjwbfR6wAGJMWrU0HfZ+q3igiLxHnf01VPTutydLsvy89jgVLNxAIhIjEmm/y/D5umnyy6+P3l+5eRsAJtL1jTEhD1IRr0pgozTx9iM4yvjc/eDu3fKcxJrHWrgD+Eft+dyaCZNqQAfvx2N2X8cTzH7L0k00M6FvKpecdyegRfd2ORmleKT7xEtZI2zsD+Z58xnRPXadzxuVNAE9PiNQDTVda8yFFF7qVyph9XmvrAcyP/TgPqFdVB0BEvMA+Mcaxf0UpP77ua27HaOG48mOZuvkNiFMAJPZJWWMXZfmefEZ3G0W+J59pm6dTmteDw0oPxe9JbihrNhDxQK8n0F3fh9BywAOeHkiPuxFvf7fjGbPPSmYU0AfAyapaE3tcAryhqkdnIF8zqRwFlCp19UF27q6j937d8Pu9KXvdJbs+5sG1/0fYCePgUOor5eLBFzGkaBCf1Kxm5tZZOKpMKjuK+TsXsLRqGaoOXvHh9/j46egf06+wX8ryZIpGtoA2gHeQ601xxuwrEo0CSqYALFTVw9ralgnZVABCoQj3PPwmr89chsfjwesRrrr4GC44Y2zKjhHRCBvqNpLn8dO3oG/cE+L0LTN4ZsOzBJ3mHcZ9Cyr47SF3pCyLMabrSlQAkrkRrFZE9pzVRGQcXw7Wzll/eOwt3nhnOcFQhIZAiNr6IH998h1mvL+y3a8VCIRYtHwja9ZvpWlB9oqXIcWD6VfYL+Gn4be3zmxx8gfYHtzOlobKdmcxxuSOZAas3wj8S0S+IDpUowK4KK2pslwgEOLVtz4mGGreRt8QCPO35z7gxIkjk3qdjZt2cu8j05m7aD1ej+DxeOhd1o27f/ZfSS8uH0nQUSxIwueMMQaSmw10LjAK+G/gWmB0kw7inFRdFyD+sEXYuiO54ZhzF63nsh88zocL1uE4SijsEAiG2fDFTm785bNxJ5mL5+j9jsIvLTt8i7zF9C2oSOo1jDG5KdlF4Y8ADgHGAheLyGXpi5T9enYvorAw/iibgRWltNWv4jjKHX96rcUVRKPdVfV8vOqLpLJ8tc/JDCjsT74nOjDLL37yPflcN+Ia60Q1xrQqmUXh/wEMBxYCjWcsBf6exlxZzev18L3LT+Cuh6YRCDSfjG3Vp1u595Hp/PCqxHflbqrcTU1tQ8LnRYTdVcl1s+R787ntwJ+ycNciVlStpFdeTyaVHd1lp4UwxmROMn0A44Ex2tbH2hxz6gkHEnGU3zwwtdn2YCjMK9M/5vQTD2LU8PhNMIUFfiKtNPGEwhEOGpn8EE6veBnXcyzjeqZuBJIxZt+XTBPQx0Q7fs1eVq3dEnd7IBhm1pzVCX+vV2kxo0dUxF032Of18K1zJ9CzR1HKcprsphpEQ6vQyDa3o5gck8wVQBmwTETm0GS6xq4+F1BnBUNhXp6+JO5zHo+0OSPo//zwLG64/Vm2bq8mHHEIhyOU9Srh5mu+yqRxnZtK2nQdTt0/ofq30QcaQvMmIqX3IJ4uPdmu6SKSKQC3pztEV7Ro2ca4n+ABVOGkSaNa/f2yXiU8+Ydvs3TVJiq3VzN6RAV9e/dIR9S9silLdn/Mu9tm46hydNlEDi891DqMXaCB2VD1a5rdVhN8H911I9LrEddymdyRzHTQMzMRpKsJRxw8CU6aIwaXJTWOX0Ta1dafCn9f/wSzt72/Z7bRxbuXMLbn4Vwz7CorAhmmtf9Hy3sqgxCcg0a2IN4+bsQyOSRhH4CIvBv7Xi0iVU2+qkUkJWv1icipIrJSRFaLyE9S8ZqZcviBA+N25Bbk+7j8/IkuJGrbhrqNvLttdrOppgNOgI92fsSa2rUuJstRkfh9SIgfnC6/6qrpAhIWAFU9Jva9m6p2b/LVTVU7PcYwNqvoA8BpwBii9xd0mXUNC/L93HbDaeTn+fD7vHu2HXn4UI47cn+X08X38e6lOOq02B50QizeFb8/w6RR3kTiX4Q74BuW6TQmB7XaBBQ7SS9V1dYbtDtmArBaVdfGjvUM0fWGl6XhWGlx/FEH8NSICt54Zzk1tQ1MHDuMQ8cMyNqmlEJvAR7xtphm2iteiryZWXdXtQHqX0KDs8HbHym8CPGlbjW1rkRKJqMNL4PWAI33kxRCyQ8Rad+qdMZ0RKsFQFUjsSaaQar6WYqP3R/Y0OTxRuDIvXcSkcnAZIBBg7LvRNGnrDuXntcidlYa32scT372TIvtHoQj95uQ9uOrU41uPx8im4m2ffvQ2ieg5wNI/jFpP362EW8FlE1Bax6E4Gzw9EZKJiP5x7sdzeSIZEYB9QSWxoaB1jZuzNQwUFV9CHgIotNBZ+KY+6oSXwk37H89f/rkL9GZjAQcVa4ZdhU983qm/fha+yhEPgcaZy8NA2F09y1Q/m50YZgcI94KpMftbscwOSqZAnBbmo79OdB0wdcBsW1Zb+1nW3nyhTms3bCdUcP78K1zj0x69s5UqwnXMGPLTFbVfELfggpO7nMSvQvKE+5/cI+DuH/sfayoWoGDE11NzJuhBd4aXuPLk38TWgeRteAbkZkcxhig9UXhC4jO/jkCWAI8oqrhRPt3wFxgfxEZSvTE/w3gmyl8/bRYuHQDN9/xb4KhCI6jrF2/lTffXcFf7vgmI4YkPvGmw47gDn7x8a+oj9QT0hBLdy/j7a0zuXnkDzmgW+KO6DyPn0NKD85g0hhJ0M+gERC789mYTGvtmvtvROcBWkJ0pM7vU3ngWDH5LvA6sBx4VlWXpvIY6XD3Q2/SEAjvma454ij1DSHuf3xGxrM8t+F5asI1hDQUzUKEgBPk4bWPtTkjqRuk6NI4RcADvhGIt+stX2lMV9daE9AYVT0YQEQeAeak+uCq+irwaqpfN1XC4Qjvzl3Duo3bGTygFxMOHcL6z3fE3XfJyuSmb06lRbuX4NByWOf24HZqwjV082fZdAKFX4fQPKh/CST2T8/TE+n5J3dzGZOjWisAocYfVDWcrUMb02Xn7lquufUpdu6uo6EhRGGBn24lBfj9XoLBli1h3Yoz1I7eRIGngBriLUCj5HnyMp6nLSIepMev0eJrIbQIPOWQN6HVzl8NLkLr/hYdOZR/PFJ0MeKxqa6NSYXWCsChTe74FaAw9lgATcXNYNnsvkfeYsu2aiKR6CfsuoYQgWCYPuXd2b6zlkCTIpCf5+PCM8Yl/drbAztYUb2SEl8JB3Yfjc+TTF98Syf3OZHnN75IUL/sWPWJl0N6HJK5jt0OEN8gSGLsv1P3IlTdRnQOQoXQErTuKSh7EfG40+luzL4k4ZlHVb2ZDJJtZs1Zvefk3yjiKFu2VnH8UQfw7tzV0auBUITTTjyQb5w9vs3XVFX+ueFfvLnlLTziQRDyPHn8eNRNDCga0O6MX6s4hc/qNjB3x3x8Hi+OOvQv7M93hl3RbL+qUBWOKqV56Z9sLlVUg1D9S6DpwjkBcLajtY8h3X7gVjRj9hkd++iZw1Th+suP54YrT2TTlt0M7NeT0u7JjWBZuGsRb1W+He20jfXRNjgN3LPqD/z+0N+1+w5ij3i4ZvjVnDfg63xWt4GyvDIGF3/5yXpzwxb+svqvbKyPjq6tKOjDtcMnM7ADxSbjwp+w54/UTBAC08EKgDGdlnt33iTp2Akj8Hpb/nkUuPi7jzBn4ToOHtU/6ZM/wFuVbzebiK1RTbiWdXXrO5y1PL+ccT3HNjv5B50Qdyz7LevrPiOsYcIaZmP95/x6+Z3Uhes6fKyMke6QaNSxp1dmsxizj7ICkMCN3/kKfcq6tVjYRVUJhiLc/ddp7NzdvhNpQ6TlyR+iUzEEEjzXUQt2LiToBNG9PkWHNcyHO+am9FjpIL6B4BsJ7N0SWYgUXe5GJGP2OVYAEujZo5in/nglEw4dHPd5j8fD7Hlr2vWaR+13RNzROQoMK0nt7I/bg9sJOaEW24NOkG2BrrH0oPT8M/j2BwpBSoB8KLkGKTjJ7WjG7BOsD6AVPp+XAf16IbKGuPdVtfNeq2PLj+Xdbe/xef0XBJwAHjz4PF6uHHoFeR5/SjI3GlY8FJ/HR8RpPvNnvief4SkuNuki3t5I2RQ0tBKcbeA/CPF0nY5sY7KdFYA2nDRpJM+/tqDZsE8Ax3GYdET7TqR5Hj8/G/0T5u2cz8Jdi+nh787x5cfRr7BvKiMDMLLbAQwuGsSntev23CnsFx+983tzaOkhbf5+bbgWRSnxlaQ8W3uJfyQw0u0YxuxzJBunDEhk/PjxOm/evIwf96EnZ/HPl+cTjjh4Y+sA33T1yZxxkgvz6bRD0Anx2qbXmLV1Ng4OE/c7irP6nUGBN/Fc85UNW3lwzUN7OqUHFg7gmuFXp6VIGWMyQ0Tmq2qLsepWAJL06YZtvDt3DX6flxMmHkBF+b53H1zICXHToluoClU36zwu9hZzz2G/a7VwGGOyV6ICYE1ASRo6sIyhA8s6/PthJ8zqmjUoSkV+BdWRanrnl2fVSfWjnQsIROKPHJqzYy7HlR/rUjJjTDpYAciA5VUruP+TB4g4EUIaIoKzZzTQaRVf49z+52TFMpLbAtsIOi3n6w84ASobtrqQyBiTTjYMNM1qw7Xcu+qP1EbqaNAAkdjsnUEnSNAJ8trm15m19V2XU0YNKR6CP85opAJPPsNKhrqQyBiTTlYA0mzujnm0Nl406AR5ZfNrmQvUijHdR9O/sD9++fLC0Cc+yvLLkho5tK9TddD653G2X4iz7Vyc2sdRTe0NfMZkkjUBpVldpJ7wXmPx91YVqs5QmtaJCD8ZdTNTvniF2dveQy4qse8AABAESURBVFEm7nck5/Q/C6/k9NyAAOjuH0HDm0QXtAeq16ANr0KvpxCx/5VM12P/atNsTPfReD3eFjdkNaWqLKtazpjuozOYLL58bz4XDDyPCwae53aUrKKhFdAwjeazkzZAeBUE3oaCk11KZkzHWRNQmg0pHswRPceTJ4kXaKl36rl31R9ZVrU8pcdWVQKRAI62XDXMtFNoPnGb8rQODbyf8TjGpIJdAWTAxYMuZMnujwmHQzgJ+gOCTpC/rnmYa4dfzahuIzs9KuiD7R/y9GfPUhWqIs+Tx2l9v8bZ/c7E08rqW6YVnv2iy1i2aPPPA29vVyIZ01l2NsiAl794lbpIbcKTf6NdoV3cu+qP3LnibsJOgqmQk7Bo12Ie+fRxdoV24eDQ4DTwyqbX+M/nUzr8mjkv/0QgznxN4kUKv57xOMakghWADJi7cz5hbb0juFHACbCmZi1vbnmrw8d7fuN/WoznDzpBpm5+o1OFJZeJ5CO9ngDvIKKzkxaDZz+k9K+It4/b8YzpEGsCyoD8di7QHtQgs7a9y9cqvkpIQ/jF364moa2B+DdtOepQG6mlh82o2SHiPwDKpkFkDWgQfCMRGx1lujArABlwUp8Teeazf+2ZlTMZ1eEarvvoBuoi0UVnir3FnNXvDL5W8dU22/EHFA1gZfWqFts9Ilkxu2dXJiLgG+F2DGNSwpqAMuDIXhNQkh+J4xUv1aHqPSd/gNpILf/a8G8e/fRvbf7++QPOa3YzV6OIRpi66Y2kcxhj9m1WADJg9rb38bTRVCBEm3jyPfmgihOnYESI8MH2D9kR3NHqax3QbX9GxbmnIKwR/vPFlJQvP2mM6ZqsCSgDPq1dF3eSNYhOtdDL35MTeh9PWMMMLR7C71fdl/C1fB4fG+o20iuv9YXRKxu2xN3uwUNlYCsDiwYk/waMMfskKwAZMKhoIPN3ftSiD8AnPi4dfAnHlx/brJO31F/KrtCuuK8V0Qjl+W1PS12WX8aWQGWL7WEN08NvncDGGGsCyojjyo9pMcumT7wMLBrQ4uQPcOHA8+O24XvwMKRoCP0K+7V5zLP6ndFiAXq/+Dms9FC6+7t14F0YY/Y1VgAyoJu/G7eN+Skjux2AIPjEx5G9JnDLyJviDu9U1RaLsnjwMLbn4fzggO8ldczR3Ufx7SGXUeIrJs+Th098jO85lsnDvpOS92SM6fpsScgMc9RBkITj+jfXb+bnH9/eorkoT/K4f+y97V5BzFGHHcEdFPuKKfQWdji3MabrSrQkpF0BZJhHPK3e1DV72/txJ2/ziLBg16IOHa8sv8xO/saYFqwT2GURjTB723u8s/VdFMWPnwgtp41wUBoiDXFeIXepsxs0hHg7vlazMbnMCoCLVJX7P3mAZVXLCcSGifrFhyAt+gBUlYN7HOhGzKyjkc3orpsgtBAQ1DsAKb0L8R/sdjRjuhQrAC5aXbOGZVUr9pz8AUIaxoMHn/j29APkefI4ruxYnlz/DEt2f4xXvEwqm8hZ/c6k0FvQ7n6Brkw1gu74JkS+gMab5SJr0R2XQdk0uxowph2sALhoRfVKQk7L+YEcHCb0HI8Cfo+PCT2P4P8+fZSacA2KEtIQ0ytnML1yBh487N9tfyYPu5KyJO4P6PKCH4CzE/a+U1rDaP2/kZJrXIllTFdkncAu6u7v3uL+AIh+4h/ZfSTXjbiGq4d9h8rAVgJOoEWzEESLxSfVn/C/y36TG1M9Rz6HuCucBSCyLtNpjOnSrAC46Iie4/bMAdSUB+HIXkfsebyubn3CqSQgWgTqIw0s2LUwLTmziv9g4i7NKEWI/4iW240xCblSAETkLhFZISKLReQFESl1I4fbinxF/GjUDyn19yDfk0+BJ58e/u7cNPIHFPuK9+w3sHBAi7t69xZyQmwNbEt3ZNeJfzTkHwU07ffwR5dsLDzdrVjGdElu9QFMA25V1bCI3AncCvzYpSyuGlEynHsPu5sNdRtQovMG7T3f/7Hlk5jyxcuECMVtBoJoX8HgokEZSOw+Kf0TWvsY1P8zujBLwdeQku8hkjud4cakgisFQFWbTkr/AXC+GzmyhUc8DC4enPD5Yl8x/+/An/H4p39nRfVKFEX4siHEJz76FvRldPdRGcnrNpG8aGevdfga0ymuTwUhIi8B/1TVJxI8PxmYDDBo0KBx69evz2S8rOOoQ124nhc+/w8f7piD4GF4yTC6+UroldeLY8onJTVbqDEmdySaCiJtBUBE3gQq4jz1M1V9MbbPz4DxwHmaRJB9YS6gVAo7Ye5ccTfr6z4j4ATwiRePeLl+xLUcVnqo2/GMMVkiUQFIWxOQqp7cRqArgDOBk5I5+ZuW3tn6brMRQmGNgEb465qHuf/we/F57DYPY0xibo0COhW4BThbVeva2t/E99729+MOD3XU4dPadZkPZIzpUty6D+BPQDdgmogsFJEHXcrRpSUaGqqoffo3xrTJrVFAI9w47r7mxN7Hs7pmDQGn+SLvxb6inBkSaozpOLsTuAsb33McR+93FH7xk+fJo8BTQLG3mBv3v6HFvQTGGLM3ayfowkSEK4ZexqkVp7CieiUlvhIOLT0k7vxCxhizNysA+4CKwgoqCuONuDXGmMSsncAYY3KUFQBjjMlRVgCMMSZHWQEwxpgcZQXAGGNylOuzgbaHiGwF3JoOtAzIxhVXsjUXWLaOytZs2ZoLLFtbBqtq+d4bu1QBcJOIzIs3m57bsjUXWLaOytZs2ZoLLFtHWROQMcbkKCsAxhiTo6wAJO8htwMkkK25wLJ1VLZmy9ZcYNk6xPoAjDEmR9kVgDHG5CgrAMYYk6OsACRJRO4SkRUislhEXhCR0izIdKqIrBSR1SLyE7fzNBKRgSIyQ0SWichSEfm+25maEhGviCwQkZfdztKUiJSKyHOxf2fLRWSi25kaicgPYv8tPxaRp0WkwMUsj4pIpYh83GRbLxGZJiKfxL73zJJcWXfeaMoKQPKmAQep6iHAKuBWN8OIiBd4ADgNGANcLCJj3MzURBi4SVXHAEcB12dRNoDvA8vdDhHHH4CpqjoKOJQsySgi/YEbgPGqehDgBb7hYqTHgVP32vYTYLqq7g9Mjz3OtMdpmSurzht7swKQJFV9Q1XDsYcfAAPczANMAFar6lpVDQLPAOe4nAkAVd2kqh/Ffq4meiLr726qKBEZAJwBPOx2lqZEpAdwHPAIgKoGVXWXu6ma8QGFIuIDioAv3Aqiqu8AO/bafA7wt9jPfwO+ntFQxM+VheeNZqwAdMyVwGsuZ+gPbGjyeCNZcpJtSkSGAIcDH7qbZI/7gFsAx+0gexkKbAUeizVPPSwixW6HAlDVz4G7gc+ATcBuVX3D3VQt9FHVTbGfNwN93AyTQDacN5qxAtCEiLwZa+Pc++ucJvv8jGgTx5PuJe0aRKQE+Ddwo6pWZUGeM4FKVZ3vdpY4fMBY4C+qejhQizvNGC3E2tPPIVqk+gHFIvItd1MlptGx7Vk1vj1bzxu2JGQTqnpya8+LyBXAmcBJ6v4NFJ8DA5s8HhDblhVExE/05P+kqj7vdp6YScDZInI6UAB0F5EnVDUbTmYbgY2q2nil9BxZUgCAk4FPVXUrgIg8DxwNPOFqqua2iEhfVd0kIn2BSrcDNcqy80YzdgWQJBE5lWjTwdmqWud2HmAusL+IDBWRPKKdclNczgSAiAjRtuzlqnqP23kaqeqtqjpAVYcQ/Xu9lSUnf1R1M7BBREbGNp0ELHMxUlOfAUeJSFHsv+1JZEkHdRNTgMtjP18OvOhilj2y8LzRjN0JnCQRWQ3kA9tjmz5Q1WtdjETsk+x9REdlPKqqd7iZp5GIHAPMApbwZVv7T1X1VfdSNSciJwA3q+qZbmdpJCKHEe2czgPWAt9W1Z3upooSkV8CFxFtxlgAXKWqAZeyPA2cQHSa5S3AL4D/AM8Cg4hOGX+hqu7dUexGrlvJsvNGU1YAjDEmR1kTkDHG5CgrAMYYk6OsABhjTI6yAmCMMTnKCoAxxuQoKwAmY0QkIiILY3dX/0tEihLs914HX3+8iPyxE/lqEmyvEJFnRGSNiMwXkVdF5ICOHicbiMgJInJ0gudGicj7IhIQkZsznc1kjhUAk0n1qnpYbEbJINBsPHRsojFUNe6JqS2qOk9Vb+h8zGaZBHgBeFtVh6vqOKJju7Nxrpn2OIHo3bzx7CA6++fdGUtjXGEFwLhlFjAi9kl0lohMIXbna+Mn8dhzbzeZI//J2AkZETlCRN4TkUUiMkdEusX2fzn2/O0i8o/YJ9lPROTq2PYSEZkuIh+JyJKm8zwlcCIQUtUHGzeo6iJVnSVRd8WuaJaIyEVNcs8UkRdFZK2I/FZELonlXCIiw2P7PS4iD4rIPBFZFZurCBEpEJHHYvsuEJETY9uvEJHnRWRq7D39rjGTiJwSe68fxa6uSmLb14nIL5u831ESnaDvWuAHsSuyY5u+YVWtVNW5QKgD/11NF2JzAZmMi33SPw2YGts0luic6Z/G2f1w4ECi0w/PBiaJyBzgn8BFqjpXRLoD9XF+9xCi6xEUAwtE5BWic8Scq6pVIlIGfCAiU1qZo+UgINHkcecBhxGdu78MmCsi78SeOxQYTfTT9FrgYVWdINHFcb4H3BjbbwjRqb2HAzNEZARwPdE5zQ4WkVHAG02anA6L/U0CwEoRuT/23n8OnKyqtSLyY+CHwP/Efmebqo4VkeuI3v18lYg8CNSoqn3Kz2FWAEwmFYrIwtjPs4jOF3Q0MCfByZ/YcxsBYr87BNgNbIp9SqVxptHYxUFTL6pqPVAvIjOInmhfAX4tIscRnaaiP9HmnM0deD/HAE+raoToZGQzgSOAKmBu4/TEIrIGaJw+eQnRq4pGz6qqA3wiImuBUbHXvT/23laIyHqgsQBMV9XdsdddBgwGSokuCjQ79jfIA95vcozGyfjmEy1axgBWAExm1avqYU03xE5Yta38TtP5ZiK079/s3p/qFbgEKAfGqWpIRNYRnRk0kaXA+e04ZqOmuZ0mjx2av4d4GZN93ca/hwDTVPXiNn6nvX8/s4+zPgDTFa0E+orIEQCx9v94J7ZzYu3p+xHt9JwL9CC6JkAo1rY+uI1jvQXki8jkxg0ickis3XwWcJFE1xguJ7qi15x2vpcLRMQT6xcYFntvs4gWKmJNP4Ni2xP5gGjT2IjY7xRL26OUqoFu7cxq9jFWAEyXE1sC8yLgfhFZRHTd1Xif4hcDM4ieIH+lql8QXZBjvIgsAS4DVrRxLAXOBU6W6DDQpcBviDYZvRA7xiKiheKW2LTO7fEZ0aLxGnCtqjYAfwY8sYz/BK5obebN2Dz9VwBPi8hios0/o9o47kvAufE6gSU67HUj0X6En4vIxlg/i9nH2GygZp8kIreT5Z2cIvI48LKqPud2FpOb7ArAGGNylF0BGGNMjrIrAGOMyVFWAIwxJkdZATDGmBxlBcAYY3KUFQBjjMlR/x8z01uOCqwJKQAAAABJRU5ErkJggg==\n"
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "The principal components are linear combinations of the original features. Here, we plot out how each principal component weights the original features. "
-      ],
-      "metadata": {
-        "id": "_IvfS47uZjOm"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Show the weights of different features in the first two principal components\n",
-        "\n",
-        "pca_weights = pca.components_\n",
-        "fig, (ax1,ax2) = plt.subplots(2,1)\n",
-        "fig.tight_layout()\n",
-        "ax1.bar(scalar_cols,pca_weights[0])\n",
-        "ax1.set_xticks([])\n",
-        "ax2.bar(scalar_cols,pca_weights[1])\n",
-        "plt.xticks(rotation=30, ha='right')"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 370
-        },
-        "id": "gWBrKL0L1eO2",
-        "outputId": "f5503671-146d-4c6e-dadf-1c234a1e86ae"
-      },
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\n",
-              " <a list of 11 Text major ticklabel objects>)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 12
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 432x288 with 2 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAakAAAE9CAYAAACx250OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3de7ylc93/8dd7Zozz2TgOM0TleJONyqlyiBS6I5RCNJXcpXIYKaTU4A71SyEUqYRSU0hFOtwhe0qKDqaJGymDDnfp5h4+vz8+39W+ZrX32Hsd9rr23u/n47Eea12Htb7fa61rXZ/r+72+3++liMDMzKyOJvU6A2ZmZkNxkDIzs9pykDIzs9pykDIzs9pykDIzs9pykDIzs9rqepCStJekX0uaL2n2EtZ7jaSQ1NftPJmZ2djQ1SAlaTJwPrA3sBlwiKTNBllvReCdwO3dzI+ZmY0tU7r8+dsD8yNiAYCkK4H9gHua1vsgcCZw/HA+dI011oiZM2d2MJtmZtYr8+bNezQipg22rNtBaj3ggcr0g8AO1RUkvQBYPyKukzSsIDVz5kz6+/s7l0szM+sZSfcPtaynDSckTQLOAd4zjHVnSeqX1L9w4cLuZ87MzHqu20HqIWD9yvT0Mq9hRWAL4BZJ9wEvBOYO1ngiIi6KiL6I6Js2bdBSoZmZjTPdru67A9hE0oZkcDoYeF1jYUT8BVijMS3pFuC4iBjXdXkzZ1/X9TTum7NP19MwM+u2rgapiFgk6RjgRmAycGlE3C3pdKA/IuZ2M/0lcaAwM6u/bpekiIjrgeub5p0yxLov6XZ+zGxi8Qnp2Nb1IGX14z+tmY0VHhbJzMxqyyUpM+s6l96tVQ5SZmZd5ADdHlf3mZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbXU9SEnaS9KvJc2XNHuQ5e+WdI+kuyTdJGlGt/NkZmZjQ1eDlKTJwPnA3sBmwCGSNmta7adAX0RsBVwDnNXNPJmZ2djR7ZLU9sD8iFgQEU8BVwL7VVeIiO9GxBNl8jZgepfzZGZmY0S3g9R6wAOV6QfLvKEcCdww2AJJsyT1S+pfuHBhB7NoZmZ1VZuGE5IOBfqAswdbHhEXRURfRPRNmzZtdDNnZmY9MaXLn/8QsH5lenqZtxhJuwMnA7tGxJNdzpOZmY0R3S5J3QFsImlDSVOBg4G51RUkbQNcCOwbEY90OT9mZjaGdDVIRcQi4BjgRuCXwFURcbek0yXtW1Y7G1gBuFrSnZLmDvFxZmY2wXS7uo+IuB64vmneKZXXu3c7D2ZmNjbVpuGEmZlZMwcpMzOrra5X95lVzZx9XdfTuG/OPl1Pw8xGh4OU2ShxgDYbOVf3mZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbTlImZlZbXmAWZswRmOAV/Agr2ad5JKUmZnVloOUmZnVloOUmZnVVteDlKS9JP1a0nxJswdZvrSkL5Xlt0ua2e08mZnZ2NDVICVpMnA+sDewGXCIpM2aVjsS+FNEbAycC5zZzTyZmdnY0e2S1PbA/IhYEBFPAVcC+zWtsx9wWXl9DbCbJHU5X2ZmNgZ0O0itBzxQmX6wzBt0nYhYBPwFWL3L+TIzszFAEdG9D5cOAPaKiKPK9BuAHSLimMo6vyjrPFimf1vWebTps2YBswA22GCDbe+///6u5dtsvBmNPmLuH1Y/Y+V3lzQvIvoGW9btktRDwPqV6ell3qDrSJoCrAw81vxBEXFRRPRFRN+0adO6lF0zM6uTbgepO4BNJG0oaSpwMDC3aZ25wGHl9QHAzdHN4p2ZmY0ZXR0WKSIWSToGuBGYDFwaEXdLOh3oj4i5wCXA5yTNBx4nA5mZmVn3x+6LiOuB65vmnVJ5/b/Agd3Oh5mZjT0eccLMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGrLQcrMzGqra0FK0mqSvi3p3vK86iDrbC3pVkl3S7pL0kHdyo+ZmY093SxJzQZuiohNgJvKdLMngDdGxObAXsB5klbpYp7MzGwM6WaQ2g+4rLy+DNi/eYWI+E1E3Fte/x54BJjWxTyZmdkY0s0gtVZEPFxe/wFYa0krS9oemAr8tot5MjOzMWRKO2+W9B1g7UEWnVydiIiQFEv4nHWAzwGHRcQzQ6wzC5gFsMEGG7ScZzMzGzvaClIRsftQyyT9UdI6EfFwCUKPDLHeSsB1wMkRcdsS0roIuAigr69vyIBnZmbjRzer++YCh5XXhwFfa15B0lTgWuDyiLimi3kxM7MxqJtBag6wh6R7gd3LNJL6JF1c1nktsAtwuKQ7y2PrLubJzMzGkLaq+5YkIh4Ddhtkfj9wVHl9BXBFt/JgZmZjm0ecMDOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2lLE2Bu8oa+vL/r7+3udDTMz6wBJ8yKib7BlLkmZmVltOUiZmVltOUiZmVltjclrUpIWAvf3Oh9mZtYRMyJi0BvejskgZWZmE4Or+8zMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLYcpMzMrLam9DoDrVhjjTVi5syZvc6GmZl1wLx58x6NiGmDLRuTQWrmzJn09/f3OhtmZtYBku4fapmr+8zMrLYcpMzMrLYcpMzMrLY6ck1K0l7Ax4DJwMURMadp+eHA2cBDZdYnIuLisuww4H1l/oci4rJO5Mms2czZ141KOvfN2adn6Q+VttlY1XaQkjQZOB/YA3gQuEPS3Ii4p2nVL0XEMU3vXQ04FegDAphX3vundvNlZmZjXyeq+7YH5kfEgoh4CrgS2G+Y73058O2IeLwEpm8De3UgT2ZmNg50IkitBzxQmX6wzGv2Gkl3SbpG0vojfC+SZknql9S/cOHCDmTbzMzqbrQaTnwdmBkRW5GlpRFfd4qIiyKiLyL6pk0btM+XmZmNM50IUg8B61empzPQQAKAiHgsIp4skxcD2w73vWZmNnF1IkjdAWwiaUNJU4GDgbnVFSStU5ncF/hleX0jsKekVSWtCuxZ5pmZmbXfui8iFkk6hgwuk4FLI+JuSacD/RExF3iHpH2BRcDjwOHlvY9L+iAZ6ABOj4jH282TmZmNDx3pJxUR1wPXN807pfL6JOCkId57KXBpJ/JhZmbji0ecMDOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2nKQMjOz2urIALNmZlY/M2df1/U07puzT1c/3yUpMzOrLQcpMzOrrY5U90naC/gYedPDiyNiTtPydwNHkTc9XAi8KSLuL8ueBn5eVv3viNi3E3kyswHjodrHJqa2g5SkycD5wB7Ag8AdkuZGxD2V1X4K9EXEE5LeBpwFHFSW/SMitm43H2ZmNv50orpve2B+RCyIiKeAK4H9qitExHcj4okyeRswvQPpmpnZONeJILUe8EBl+sEybyhHAjdUppeR1C/pNkn7dyA/ZmY2ToxqE3RJhwJ9wK6V2TMi4iFJGwE3S/p5RPx2kPfOAmYBbLDBBqOSXzMz661OlKQeAtavTE8v8xYjaXfgZGDfiHiyMT8iHirPC4BbgG0GSyQiLoqIvojomzZtWgeybWZmddeJIHUHsImkDSVNBQ4G5lZXkLQNcCEZoB6pzF9V0tLl9RrAjkC1wYWZmU1gbVf3RcQiSccAN5JN0C+NiLslnQ70R8Rc4GxgBeBqSTDQ1HxT4EJJz5ABc05Tq0AzM5vAOnJNKiKuB65vmndK5fXuQ7zvR8CWnciDmZmNPx5xwszMastByszMastByszMastByszMastByszMastByszMastByszMasu3jzcz6yLfy6s9LkmZmVltOUiZmVltOUiZmVlt+ZrUBOQ6cptIvL+PbS5JmZlZbTlImZlZbTlImZlZbXXkmpSkvYCPkTc9vDgi5jQtXxq4HNgWeAw4KCLuK8tOAo4EngbeERE3diJPdeY6cjOz4Wm7JCVpMnA+sDewGXCIpM2aVjsS+FNEbAycC5xZ3rsZebv5zYG9gE+WzzMzM+tISWp7YH5ELACQdCWwH1C9Dfx+wGnl9TXAJ5T3kd8PuDIingR+J2l++bxbO5CvJXJpxmz0+P9mrerENan1gAcq0w+WeYOuExGLgL8Aqw/zvWZmNkEpItr7AOkAYK+IOKpMvwHYISKOqazzi7LOg2X6t8AOZOnqtoi4osy/BLghIq4ZJJ1ZwCyADTbYYNv777+/rXxbb/iM2syaSZoXEX2DLetESeohYP3K9PQyb9B1JE0BViYbUAznvQBExEUR0RcRfdOmTetAts3MrO46EaTuADaRtKGkqWRDiLlN68wFDiuvDwBujizCzQUOlrS0pA2BTYAfdyBPZmY2DrTdcCIiFkk6BriRbIJ+aUTcLel0oD8i5gKXAJ8rDSMeJwMZZb2ryEYWi4C3R8TT7ebJzMzGh470k4qI64Hrm+adUnn9v8CBQ7z3DOCMTuTDzMzGF484YWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmteUgZWZmtdVWkJK0mqRvS7q3PK86yDpbS7pV0t2S7pJ0UGXZZyX9TtKd5bF1O/kxM7Pxpd2S1GzgpojYBLipTDd7AnhjRGwO7AWcJ2mVyvLjI2Lr8rizzfyYmdk40m6Q2g+4rLy+DNi/eYWI+E1E3Fte/x54BJjWZrpmZjYBtBuk1oqIh8vrPwBrLWllSdsDU4HfVmafUaoBz5W09BLeO0tSv6T+hQsXtpltMzMbC541SEn6jqRfDPLYr7peRAQQS/icdYDPAUdExDNl9knA84HtgNWAE4d6f0RcFBF9EdE3bZoLYmZmE8GUZ1shInYfapmkP0paJyIeLkHokSHWWwm4Djg5Im6rfHajFPakpM8Ax40o92ZmNq61W903FzisvD4M+FrzCpKmAtcCl0fENU3L1inPIq9n/aLN/JiZ2TjSbpCaA+wh6V5g9zKNpD5JF5d1XgvsAhw+SFPzz0v6OfBzYA3gQ23mx8zMxpFnre5bkoh4DNhtkPn9wFHl9RXAFUO8/2XtpG9mZuObR5wwM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7PacpAyM7Paaut+UpJWA74EzATuA14bEX8aZL2nyRsbAvx3ROxb5m8IXAmsDswD3hART7WTJ6u3++bs0+ssmNkY0m5JajZwU0RsAtxUpgfzj4jYujz2rcw/Ezg3IjYG/gQc2WZ+zMxsHGk3SO0HXFZeXwbsP9w3ShLwMuCaVt5vZmbjX7tBaq2IeLi8/gOw1hDrLSOpX9JtkhqBaHXgzxGxqEw/CKw3VEKSZpXP6F+4cGGb2TYzs7HgWa9JSfoOsPYgi06uTkRESIohPmZGRDwkaSPgZkk/B/4ykoxGxEXARQB9fX1DpWNmZuPIswapiNh9qGWS/ihpnYh4WNI6wCNDfMZD5XmBpFuAbYAvA6tImlJKU9OBh4aT6Xnz5j0q6f7hrNtBawCPjnKadUnf2z7x0u51+t723ulF+jOGWtBW6z5gLnAYMKc8f615BUmrAk9ExJOS1gB2BM4qJa/vAgeQLfwGff9gImJam/keMUn9EdE32unWIX1v+8RLu9fpe9sn5rYPpt1rUnOAPSTdC+xeppHUJ+niss6mQL+knwHfBeZExD1l2YnAuyXNJ69RXdJmfszMbBxpqyQVEY8Buw0yvx84qrz+EbDlEO9fAGzfTh7MzGz88ogTw3fRBE7f2z7x0u51+t72iZv+YhThhnJmZlZPLkmZmVltOUiZTWCS/uWask0MZdSf2nOQatLrH65X6UuaJGnC7Q+SJk/U9CUtC+wkafkepf88SSv0Iu06pN8rklaCHICh13kZjgl3UBqKpGmSJvfqh+tl+pJ2BHaOiGckDTa6yLgVEU8DSDpI0uqjlW7jhCAinpY0RdKo9f1rBMaI+AdwOnCUpKmjlX7Jw8rA3mTXk1FXg/SPl/T2XqQNnCNpR0lbSTqgR3kYNgcp/nnAeDXwRknLSzpoIqRfKbU9Alwq6ePA3NEKVL0ouamiTO8m6fvAG4HlRqskGxHPlPTfBvwXsF23vw9JM0vaT1fyEcCrgFO7mXYlD40A+ZeIOA/YRNLmo5F2TdJv/MYXRMT5pTQ7Gumqsm/fDXwP+Bg55mqtTeggVdlhnwHuAc4D7gCeGo2DVa/Sb+ywZdQPAQuB/yVHpX9xRHR1x62UIhoH6jdK2qdR7dTNbY+CgT6C+wMXRsQ+EfEA7Y/CMmySTgdeARwQEdc3vo8upDNF0ruAt0iaKunVkj4p6aiyynuAVyrH1uyKMtrMYgGy/N6vBI7tVrp1Sb+kN6nxG0fE/5Tf/wddTlMlvQAa/6sngN8C34qIH0oatX2+FRMySFWrWiqzpwO/Au6MiGu7We3Wy/TLHyVKgNoR2AtYCjgIWBrYpJrHDqet6h9V0gqSTgXeQpZkTpS0aqe3vXlbJO3NwBBcS5EH6E9Kugy4UNILO5Suqs/l9eqS9iuTjwG/BjaUdIikwyVt3Im0K+lNKmNj3kP+vmcBbwVuIUd7OZYcM/OrwIc6mXYlD28F3lVqCbaU9HFJB0fE38k+OatKekU30u51+pJWlvQeSc8r1enPl9QYcug0YF1JL+tG2jBw3UnSkcAN5fe+mjwhPVHS6pU7UdTShAxSlYPkSyVdJWk2edPG3YHnSBpyUN2xnn75o6wp6b3Ax4H/IG8++ShZkjuvmsdOaZTcSvrrKIfNeg+wbETsCHwEWJ4Mlp1Ks0/SRpXvu1G18gNg4xKkTyKH67qGvKfZX4FOBYpGSbkadJ8HfKJUvd1CjsbyGuCF5OgtJ3Qi4coZdON3/DZ5O5wdgU9ExFXALOC5wGbABcBzJe3RifRLHhqNQuYB65PB8ZPA/cDbJJ1DBupvAod3ugTd6/SLNchbEB0i6YPAtcDHJJ1Rlp9U8tQVktaXdAmwE/CfwLbkycjfgC9S/u+SNu1WHtoWERPiQem4XF6vQB4gbyQPENeSP9a2wJuAm8t6qwIrjuX0gclN08uRB8dGGqsARwNfKNN3kqWaM4GjOrDdk5qmXwncQP45PwH8spKvQ4FPAc9r/s5aSHdjcizIt5fpjwLvAqaW6TcB/U3v2ZwMYIe0uc3LAmcDp5bpbYE3A8uX6YuAj5XXUyvvewfwzg5/3+8mD87rl/3pC+SYmUuV5VcAp5TXbwNu6eS+Xpn3nrLfvatMrwd8A3gpWYvwOeAt7aZdk/QnN/3f9wYuBr5app9b/u8nlOmfAf/RgXQnDTJvd+B/gAMraZ9MnqAsD/w3WavwPWB6J7a/049xX5KqVK1Vz2ZfTB6I+yPiy2Sd9MPkWeZVwBRJ15PB47ljOf0YaL22taTpEfEEOer8FmX5n8kzSZVrEkcDLwLWJUe5b0sMlGIOlnQyeQ1makR8JCKOAZ6WtF/J1+3AP4A3lPeOuNqvUoKYTwacTSTNAL4OvBzYqCy/FHhC2XABSWeRB+yPR8QX29lm4P/IA+ILlLewmQ7sQP6+AO8DdpO0MxCSdpZ0M7AvcHMrCZaqVFW+75UkHUp+342D8FPkb7ouefCCrGL+R3l9KfBYKeW1k4dGFdOrJL1b2XLxU8DvycYpq0Xevmce8I6IeJDc118pac1W0q5L+pD/uYgIZRP3pcmS+h/IWpKlI+I3ZV7jv30s8H61WcVe+e1PlXSCpJ0i4jtkKfnVZZ3fAM8AMyOrO18NXBYRu5bvoXbGfZCq/HCHlbrhl0TEt8hgsJGklSPifuDvwHYR8TfgCOB64OCImDeW05e0kaQfkUX9L0valwxSt0o6saz2AHlW9XTkgMDvjog3RMQjI60CaV5f0tqSPkqWGL9NBsS/aeC6z38CJymvndxLHiw+09rW/vPmm5OULbauIgPGgRFxC7AAOFgDfWN+BpxRqgE/GxHbRMTVraZdycMispR8L3BMRHyN/I53KCcKjwA/JEtby5AlnEsiYveI+HmLaUbZ9umSrgEuJ0829oyI95W8nEJ+JwLOlnQFcHDJK8BrgdXIKrAR0eLXOpeRtA9ZYtuUbEW2LlmKm0EGbIDbgPvK65vJ6sh1R5p2ndIvr5eV9DXy2s+V5E1jLy3pvba85VtAX9kfvgt8H3hvK2lX8rCmpK8AM8nqvAsl7Un+5stJOrysuhIDVdHzIuIr5f097TM4lHEdpMqJ1bKSPkVWJf0Z+KKkl5Nnun8kq0Igz7JCeRPG30bEJyLiD+2c3fQ6/eIQ4BuRN6+8CNi1POYAp0lq3A9sdfKATmT/mcX+eMPc3qWq65eAtTt5z7AvRMSPgV+QLRj3LWl9FlgReHuZ/kFE/LaVDS3f9ySySvHs8rk3kNefXli2c0fgQElvIksQHyOrSe4Z4mOfNc2m6a0k/agEqs8DW0vahgy+a5KlOciAuRawbkTMjYjPt5D2lKbpd5BB/zqyWftWZFUjZIOJPciGMVeTQfLqiNgiIu4q68yNiJdGxP+MNC+R1xqnSjqPrMbdF/j3iHgzWYV8fER8gzx4flDS/yP3x++Vj9iGvG4y4gDZy/QrpadnJC2tLJnvANwQEVsBvyRPQBaQ+/27yv//BDIo/l/5qCdb3faKFYFVIuKIiPgkea3rJeVzfwh8VNIXSv6uaH5zLN6Qqz6GqgccLw+yhPAVYP0y/XryB9oAOJKsZrscuAvYp+m9I7omMtj6o5E+TdedyrxJ5fk84EPl9bLktaDjyvTFJd1DqVwbaeE7fmnT9PFknfcLyDO2/wd8tLJ8D7L65bVlegYwZSTfM3lB+gxggzJva2DT8vp5ZdnsMv1+stPqUuSf9qPAj4Bt29jmzYGtqr9z5fWtwNsq38VnyuvXkNdB5pNBdK0W095isP0EuBBYUF5PIQ9SxwCrlnkfIU9YAJapvH/Y3/1Q+xywc9nPTy/79YPkgX8S8HzybH5PspHGDeTJ08qV968JrDBW0h/sP1DSuBn4OXnfvMayh8hq16XJGpJbyu+/SmWdY4eTPoNcd6osewFZYtumTK9OturclCzNnU/ecLalbezVo+cZ6PoG5k75ebIV1ZQyr78cMFYnz64/PhbTJw/WkyrTL27soJXlR5LXQJ5T5h0BXFFeb0Se3TUO7iMKVGTVyO1kwJlc/uhfB74EvLMcKLYC9inr7FneN42sinlzdRuW9Ads3u7y/C0GgsH7KQfoMr0neR1my/IbXAQcMZJ0lpD+WuTZ+nvLgadRgmk0jNiVDEQrkBforwQOrXzn27WR9u7kwfB5ZCnpSrIp82rl97gH2KOs+0qy8chuZXoF4LmVzxrx91DSmNo0bwoZjB+v/DYXkx2ElyrLjyRbsE4C1qy+dyylP0SeXkNe53llmT6ObEH3b2X6EODR8npnsvTceO+/nGAuaZ+vTM+gnGgwcFxZnbz+9FZguTLvGvKEajJZuvwvYO12t3k0H2O+uq9a3SLpxZJOqM6PgWqcncg/MuQP9efImzbeDqwhabt20i7Tmyr7/VQ76nYt/UjPSNpC0rXkGdqqJf1GVd3PyIPTWZIazZ1vLReYF5DXiI4pn/fUCLMwgyw1nE3++ZYGnomIgyLiY+SZ/eFkdct8YD9Jy0fEQuBTEfHpxjaU9IfV7L1sF2TDiFdKem5EfJDsBH1YWfZL4GkyONxDlhgbnZRH3CADFtun/khWE61ONkC5gQwYW5bv/XvkRfn3RV6gv6nkc+mIWBARd4ww3akqnVHJhg4/JYP8R4Avk4H4VGAd4MNk6y0iq7eeBraStExE/C0iflOtohphPnYu6Wyj7O91UbmuuSZZG/BDSrUtcC65T+wQWfV5Hdma7Zko1zrLPjjsPjq9TF/ZIfpYldFgJG2gbJixVGTjp7uBRv+n75C1Fi9SDnX2ReBHyr5SP4iI31fSH1YVW2Ofl7STpF+SJ31zyz61qKzzGFmVuw3wBUk/JjvpLyjp/JgM3k8OJ83a6HWU7MSD0kyb7BR6fGV+4wx9e+DTZL+Ar5EH1nXKsg3IqqnndCAf65MH41Vi8TOcrqVP9nPqJy/IfgHYdZB11iTP7K6iVPVVlrVTzTeDvJa2ADiQrPK4nNKUlQyO95PNwbcHzqE0L698xoibmZMNAu4gqxEXAJeX+fsAv6+sdwnZWGMb2iw9NaX/zvK5t1KqMclq1AuA1cv08eQB4nnkmfxSLaY1mexD1ai63I3sS3Yjpeqm7HcnkFVGq5Rlx5dl63Rge9cozysDHyz70k0lzQvJQPlCsuT29cq+fV5Z3vI+Vof0y2ctSzbR/0r5z91V8tAorW/H4iW5I8r+t2sbaTY+a1JJf3b5DzdqJL5KBu0VBsnr/sBOndrne/noeQY6sPPsW3acnciziNeX+c111quRzS0P6nD6s8lrLI16//OBFw2yXrfS35aBaqYfAOs1La/215hced32QZusUruavAAPGZS+QTaUaPTD+QKwIaXapYU0Brve9j4GDtBbkcHipWX6m+Q1v++SnXNbPrL2zFsAABPrSURBVPkgqyKbq1n2J8+UVykHravLPrgMebZ+LNli7hzgA82/R4v5WJ8sPT1ABsN1yvOXKvvdW4DPl9f7AR+p/v6t/N5l+7cEjiJLyRsBh5Xv96rKenPI0viMst3nlfnLNvLXxvffy/SXp1w3LdP/RgbJn1T+c+8gg9Hk8nt8qsyfTp44LjfS/1zTf3apyusPlLRfVKY3IUuPGw21v7b629fpMear+8jqsq+SAeDlZNXGcjHQP6jRT+nxyOGGvlTmd6q55Z/IIHVmmd6IbE6+WHVgq+k3Vyk2i2xC+nfloLALKVVaktYqy6Oy7tNqGjdvOOkPlYeI+FZEHAgsLWlWZPP5i8kBSy+RdAswFfhDRPxfRCx6tu0ZJI2nJa1YqlYaI0EsC9xXqjruIqs5Ty7LDiIPFp+PiMOijZaCUSiHtlmuLFoXeDyyf9kFZNXtHuRB6v3k2f7xwLcj4tTI6r52rUpWUS6I7F/2MLnNfyCDE2QDHEr10tci4iQY+P2H+3tXlff+nSyh3kU2Yf8WGTAXSXpeWbUxQO8DZKB+Rjku3pMR8Se12EK1Bun/HXixpM9L+gzZKu6/gOeQAZGSn6fIRguN8RHXi4gHI+KqyP5/jc8bUXW2pHcCNym7rmxJjhDza2CtUm1+LzlSzG6N91X/7yNNt7Z6HSWf7cEIqoPIP+6t5MXkd9OZYv6g6dNUQiFb9byO/MMc12665XOHfQZE/kk+w8CF+g9QOYtrN/3BPouB6sz9yVZLM8r0GuQZ757tfu/kyccvyrbdS56IHEe20GuktzWwiAxQLY9SMUgeJpMNJG4u3+mWZAD+CLB5WWcXsq/NO9pNmyVcRCcbm5wDnFSmp5IH5j+S1cg/B17V6v6zhHRXIa/v3UJ2AIWs2jqHgRET1iSDw0pL2oaR/O69Sn+Q/HyCHLGhUX26InlCem5lnesYaKyyXdP+O9wWutXjyXJkQ5xLGRg55YqS9qFk9ebRZND8MbBlJ7e5bo9al6Q0zH465WR/BfKC4CvIHfjFlNEFupF+Y345c32aHGZnKbK55wqNfLWYbrXvxVKSPqQcsWFGI81B3rYBWe10LTlI7alROYtrRUl/iqQ5wOWSDpC0YSOPMXDB9qvkGd3RpRT7aERcFtlpeSSlxn/uj5XvfW/gjIg4giwtHU4esFYD3ifpGLLq62PkkD7Pur88W9oVbyOrfHYnmxEfTDZn/hsZlCBLVr8syye18puracBhSTOUIxVU+0I9Rp617yhpjchGLg+Q1cs3kq06v1793GjzDFrZZ+/PZGD+BhkUiWz4cRfwBmWH4O8B342Iv0ZTDcZIVX+/so+NSvpL2EevIJvyP79MP0m2mHu5pOOUHWSnk9ejGnn753Y82/5Y+e1D0iqSdin/28+S1z6PJk9AnyH3xy+WtPYmT9bOjhY7gI8VtQxSrRykI6uaJpHXAH4cEQdExK+6nX7jTxER90XEZeQZ0PZl3ogOmJV0GwFwB/LC7yZky6FLq2k2eYA8w9ojIuaU97f1+0pakazS+gt59vgO4FAt3ru+kca55IH0X1oODZHfajr/rIKU9NwSDBsnGEsBfy0nA1eR1362I1tx3USejHw+It4T2equJTEwMsg6kpYps7cE5pdlHya/h7+SB6mlS3XmW8gROr4cZTicNtKuttz6elPLrWfIqu2fkiOH3EA2hf9oRHw2siq1pSrsamBVpYUs2TKQyCGmfgNML/skZJC4hbwmskdE/Odg2zSStMv0P1vIUo5P3U6/7M+N4PZiZefrxufcRrZe3VLSXuXk4CdkyfptZPeG/aPFkWEqJ4Ink//vdyoHRf4FOTzYoojYpqS5D3kSfDlZtX9OlBFSWj0hHgtqFaRaPUiXs5DnkFVOv6p83kjPploOEpWd5ONlesWRpNtcalM2t/0c8Fhkk+7jyDP1d5TlkyvrTo68NjUrIv5SdnoN94+6BI3rMF8nWzQ9AXyx+rnlTzY5In4aEWc9W0Cqqp4MlOmtyVLBq8gD8fLkdZfnM3AH1a+SHXifiIgrI+J1EdHSGINN3+GKkq4iA31jVOr+ks01I5v3PgnsEhG/Jvt4HRE5QsMvW0h7UuNZOSrJbPIk4NiIeAX5Xc9W5fbmEfEnsrPqt8jqpisjr5s0Sh0tjRhQ/j+N/XVLShP9poB7G3k95ETluJJbkh1WL4iIB8t2jPhAOUhQ/xtZQlolKtdQu5l+DNGNo7LOo+R//1TlddETyGPN7hFxQkT8rtUTQuW4gl8jq8jnkqWyvcvil5OtYyGrex8mq5l/QJas9pC0amM7Wkl/TIga1DnS1Cm1zNuZPHs6uzLvu+SAkLCElmq0MFJEm+mLvH6xDHmWc2nz5w0zH2uTB7/1yvRZZCfUFcr0S8nOmo3pSU35WL2VdJeQn5XIlmzzqbRKpDSrHuR7mNzids8iA/IJlNEUyOqOS8gDxpXktYFjyJOQPdrcrubfeneyRNYYieN2cmSQfcpv0Ggp1+iD1PJ3zOLX+UbacmuwUa7bvgbH8FvIrkRe6z2mk3lg+C1ku5X+s3bjKOtdSvZ/e9OS9qcRpv0c4MeV6UPLvr5R2S9/XvbH6ymj1pT1NgM2bPe3HwuPnmeg6QfrxEG6nds7tJv+2lR69D9LWnsD+1am31o++wvkQflY8oLw98gLpI0Lsd8g7wfU/Hknky2P2u4XU/nMSWQ/jDMr884qf6JVmtY9naz+GEljjx3IFnGfLu+/EziyLJtKVh9uSQaqt5PVYC2P1jBI+tuQgaCfPCF5S5n/ivI9b042yvgy2XjiWko/qA6k/U6ykc17yjauTl5veDUDzZuvBd48xPs72UBkLfJ6z0fJ6swzGUbT6U7lgawyPQu4qEzfQBlyaklpdDD9Z+vGMbk8L0sHGmM1ffYa5IltY1SQaWRQ+gB5YrIJlWHHGKKZ+Xh+9C7hHh+ku5D++0r6SxyPjYEhiM4gz8wbY899koExt7YgR4p4TsnHpxjoJDoNmFb5vNeXP9Zb6HDLpvL5a5NB6UbyTP8yKvedAf69pP/OJaU/2IGufAeLGDiDnk02M964TJ8IPNyl/e9kspR4UJk+jmy63jggXUQeOBsdKddtMZ3FDiosueXWG+hCy62RHNQYZy1kR7L9ZV//SmUfGPS/3Mn/WdnuU8n+V41AeXX5zzeP0djx//dYeIx+gj0+SPcy/XLgObq8fgHZIq0xpttvgJ0r655GHrCXJ0sYuzZ91lJk0+9PAit1+TdrnNH9W2VeY4TxC6gM1DnIe6vVW41AX63mehh4TXn9IrJl5psqy49p/pwR5r25aq9xANqWPBgfUKZnklWMjd9nC/IaQUuDwFbTKq9XIa9nNT57xbKtPyXPpE8gD1ifJq8BXk25UV2bv92wO5CSrVJvJEuu25MNRJ7f7fQrv8lMsuvCQuC06j7T7e0v63a8G8cw051OVnF+m2wQ8mGyhL9rJ76Dsf4Y3cR6fJDuVfoMXL9ZuhyI9ioHhSNLHtYmz56/U3nP+yhVPUMdKOhw1cMwv0NVDirDLl2QQ9bcycCQUY3PeAPwu8p67yFLbm0NU0WODrBiZfolg6xzNlnFtRxZYtqPLA03hnXqRD+jKWSp7StkKalxjeloBkbNOJYssW9BXgu9lMo1mVYOUixeSlmKHEroYAb6ljVfb2qcQHybpjP4VveTkaTf9N4TgetHO/3yf36MLMHObvc7aGE/eRl5MrgceYK0/Wjmoa6PUWndp4G+HneSN+LaizyDvAvYTjlawnlksbdhEVnV83fy5n/fq35mRPwfuSMfHRF/rWP6labVjUEsg7zGcRRZ3Xgt2UrnQPLAtLKkD0t6LzkQ7IPl/b8qn7dY66UY+YCwbYv8RzUGhP198/JGS8XK9HKlSfG7gLdG9nshBprufw74g6QPlrdcTTZWaXWkiOWU9446nfyukXQU+X02WtM18vefZDDbJbKF4a3kiBl/70TryF603JqoLWQ7kT5d6MYxXOUY8UOy8cYPgRsj779mXT47aK5qmUpWs1xDXpxejexf8x9ky7g7yKLue8kgsnfT+0faaq+n6VfedwDZMvC1JZ1ZZAlsBbK59SfIi/Trkq17PkUHBrwd7QeLV281xu5bhqw2eaj5d2GgNLUD8DvauG0CWUJ9Hdl3BHI8t1PIAHEeeQO8f9k3yOsu36SNMd6WkKdRa7nFBG8h24H0m0uWU1r9v7e5z+wDLD3a6db5MVpffE8P0qOZfuXAq/I4vKS9U2WdLcizxSPLn+HM8mhuMTepF3+UDnzfs8uB/yTy2svqZIni8MZ2VbexeV4L6TU+Y2/yrHln4LnkNaaDyrxq1d9i3yvlPkBd+B5GveUWE6iFbBe3f0wPyDreHp3/wB4fpHuVftOOPrXy+kKyk+amZF+Qxo33DiAv0j6HLN3t0px2r3eOYWxz88F+JbJa6xPkAfpm4Pyy7GCyI26jAUrHt48sKb+zpL9Ued1PVl9dCLy6rLdMt/LQvE/QxZZbTNAWsnXZfj9G59Gx+lYN3OTvaUlToyBbbF0LPCZpD0lHRA758X2y8+AM8h4p10W5XlE+b1LkDcqGVR/f6/RjYFiVw4GfSjpH0kvIFlyHk02cXwJ8WNLx5B9nIdncel5EfL/p82o9cnH1+ynXgRR5be5E8mBzJnmS8GZJ25MH58fIUlbb21e9PldGi/gMWXqaSwbP15LXl35D9j+6HXi1pBvJk5Ouf8dln7iErFb+qqS7yEFyG/2iqtdQRjJSx6bl5U7ACyVtUKa3Ijvivo5sKHAEWZK9ltwHGzfdPIIszTU+7/WSfkCOv7hL5CjrvUh/YUl/icNb9Xr7bZR1OuqRO8Pd5MH5JeToBD8h/6xnkBeIjyerPs4CXj4W06dSNUMeFJ9Ljob8EfKs7TDyGtfmTe87lBzOBcrZ9Vh9kP2HLiQD0JzK93EOZZRoslQzr7zemQ5WrVHq7skWmGcw0Bn00PJ7TyMbpVxA6W9E5dbho/g9dazlFhO0hWxd0vdj9B+tv7HHB+leps/i11Qa1TjLka2yTqssOwb4cnm9C9lZ9M7mAxQjrNLsyY7yrxeWlyE7oTaGEnq0HBRWJ++Y26haO4UcqHSbNtNvvij+YuDWyvTGZL+tl5PVjnPI0uukchDq6/H3N5WsTvoJ8PYW3t/TbgwTPX0/evdodVDESVEob771DNlcem/yRmO3R44IfhnZFBhJu0j6UjlwfAX+eVOxEY/g2+v0Y/FbWFwm6XXkjc+OJq+9NNwO/E9pAr8h8JOI2DqampZGxLCqFHtBZTTyGKjObHxXy5JN+OeX7/V24DORA7E+DrxK0nwymM2IiJ+2mP6ekl4XA4PQvqDk50clO28tq/432WpzVmS143+RTY7XAf4jIvpbSb9TIrsL3En2fzp/uO/rdTeGiZ6+1UCr0Y2swphDHhheV6bfCvyqss52ZAurKWTJ5sRORddepk/Wc19Mtl7bjuzX8N6y7EHg1PL6NOCyQd4/JoY3IXveP062emz0+TmLLBWuTHZ6/CGl1FTe0xjSaFvgFR3Iw4Hk/Zq2Ii94/5SsvnshebD6NWXEC7Iz7q/JMQQFrN3r77CDv8WEaSFbx/T96N2j1R2mpwfpGqS/Vkl/C7KJ8TcZGG5pL/LM7uNkx8Bty/wR3amzpztFVqc08nseWY36IbK66i3krSLWJavyLmCgxd5Hy3fRsfr9EmzOJ4ep+ney2uwtDNyJ9cJysNqq5PU0SpPvsfpggraQrUv6ftTr0RiJYaSq9xk6gbwHzLVl3lHA9ZJWJ8/EPww07ncT5bml+97UKP1/kOOMfRU4OSK+VNLYNCK+KemrZL+cxigHivKPaTzXUXNLszLiwQnkdZTfR8SblTcEnEYGrGPJA8OnJU0nO6e+Pp5lBJCRKL/ZheSZ86MR8ZTyvk8zyD5QJ5KjWXyG7KV/WqfSHm0qd3mOgRaqT5X5i7VQJYdt+oyk75OdP28hW6guH4O0UHX6Nqa1EtkY+j5DjdLEV8jrE435HT2TqUH6Q93C4oLyeiOyNNXSyNm9fpCNEn5IBmDIs9U7Gt8l2UjhOmCfMm8msEmX83QucFVl+oOUBgjl9xjTLSWbtvVwJkAL2bqm70e9Hq29qccH6V6nX9J4tltYHEmbvfd7skPAbuSN3XZrmv8jBpr+LkXe3+mKUczXmmQfo3eVoHgHpWP0WH0wgVvI1iF9P8bGo/U39vgg3ev0SxqD3cKi5fHn6vAg+zJdTFaj7Es2QtiUbKTwG2C1st6oHxzI6sVnSv6O6vV31ea29LQbw0RP34+x82icxbSkXMPYmLznys/KvCkx0Fy0q3qd/iB5aXvk7F4r1/LeS36vdwLrk8F/T0nfIKvcLu9R3pYl71x7deQo9GNa6ZrwIfK7/gp5XeUo4NiIeH5ZZzuy1HoUee+ytSPiTKdvE0VbQWqxD+rxQbrX6Y8n1YYeknYkb0J4pKSlI+LJHmdvXFDehuJc4Lfk9dVzyVu/fFjSg8CnI+IDkk4jR0Q/rOn9k6ONBkATPX0bO1pt3fcvykGtZy3Xep3+ODNJ0gyyBd+/kSNI4ADVUb1uoTrR07cxomNBysaPyCbAy5BNyo92cOqKXndjmOjp2xjRseo+Mxu+MtzP+8nrqSeWeWeRHaHfqhyOaj55PfBf7oDs9G2iGJVbI5vZ4sq10wuB5SXdKOkn5EgmHyrLF5A373uyebw5p28TiUtSZj3U6xaqEz19qz8HKbOa6HUL1YmevtWTg5SZmdWWr0mZmVltOUiZmVltOUiZmVltOUiZmVltOUiZmVltOUiZmVltOUiZmVlt/X+FmFJ2mzApdQAAAABJRU5ErkJggg==\n"
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['epsilon_x opt', 'epsilon_y opt', 'epsilon_z opt', 'structure',\n",
+      "       'e_form', 'shear modulus', 'structure initial', 'jid', 'bulk modulus',\n",
+      "       'gap tbmbj', 'epsilon_x tbmbj', 'epsilon_y tbmbj', 'epsilon_z tbmbj',\n",
+      "       'mpid', 'gap opt', 'composition'],\n",
+      "      dtype='object')\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "print(dft3d_df.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 965
+    },
+    "id": "VwcZc_PLmvjw",
+    "outputId": "369b2054-5c57-433f-fb2f-9a4d0c4f0f01"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>epsilon_x opt</th>\n",
+       "      <th>epsilon_y opt</th>\n",
+       "      <th>epsilon_z opt</th>\n",
+       "      <th>structure</th>\n",
+       "      <th>e_form</th>\n",
+       "      <th>shear modulus</th>\n",
+       "      <th>structure initial</th>\n",
+       "      <th>jid</th>\n",
+       "      <th>bulk modulus</th>\n",
+       "      <th>gap tbmbj</th>\n",
+       "      <th>epsilon_x tbmbj</th>\n",
+       "      <th>epsilon_y tbmbj</th>\n",
+       "      <th>epsilon_z tbmbj</th>\n",
+       "      <th>mpid</th>\n",
+       "      <th>gap opt</th>\n",
+       "      <th>composition</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>75</th>\n",
+       "      <td>21.0673</td>\n",
+       "      <td>29.1228</td>\n",
+       "      <td>17.6066</td>\n",
+       "      <td>[[3.1506963  4.30596127 3.56982179] As, [0.384...</td>\n",
+       "      <td>0.025</td>\n",
+       "      <td>19.993</td>\n",
+       "      <td>[[3.17888147 4.36479751 3.69558323] As, [0.381...</td>\n",
+       "      <td>JVASP-11997</td>\n",
+       "      <td>34.556</td>\n",
+       "      <td>0.6495</td>\n",
+       "      <td>15.0619</td>\n",
+       "      <td>14.9875</td>\n",
+       "      <td>12.4788</td>\n",
+       "      <td>mp-158</td>\n",
+       "      <td>0.0221</td>\n",
+       "      <td>(As)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80</th>\n",
+       "      <td>13.8023</td>\n",
+       "      <td>38.1854</td>\n",
+       "      <td>35.5515</td>\n",
+       "      <td>[[0.37213617 3.67987527 0.87369073] H, [1.4889...</td>\n",
+       "      <td>-1.184</td>\n",
+       "      <td>25.667</td>\n",
+       "      <td>[[0.34436223 3.69323659 0.87470146] H, [1.4990...</td>\n",
+       "      <td>JVASP-12002</td>\n",
+       "      <td>78.478</td>\n",
+       "      <td>0.0083</td>\n",
+       "      <td>16.5818</td>\n",
+       "      <td>61.5222</td>\n",
+       "      <td>53.1874</td>\n",
+       "      <td>mp-24242</td>\n",
+       "      <td>0.0038</td>\n",
+       "      <td>(H, O, F, Cu)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>6.3933</td>\n",
+       "      <td>6.9466</td>\n",
+       "      <td>6.3796</td>\n",
+       "      <td>[[ 0.92796672  1.82915421 10.16747299] O, [2.7...</td>\n",
+       "      <td>-2.086</td>\n",
+       "      <td>52.420</td>\n",
+       "      <td>[[ 0.938753    1.84002706 10.93783201] O, [2.8...</td>\n",
+       "      <td>JVASP-12010</td>\n",
+       "      <td>75.067</td>\n",
+       "      <td>2.4642</td>\n",
+       "      <td>5.2402</td>\n",
+       "      <td>5.8492</td>\n",
+       "      <td>5.3897</td>\n",
+       "      <td>mp-510584</td>\n",
+       "      <td>1.9202</td>\n",
+       "      <td>(O, Mo)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>92</th>\n",
+       "      <td>6.0838</td>\n",
+       "      <td>6.0838</td>\n",
+       "      <td>6.5652</td>\n",
+       "      <td>[[0. 0. 0.] Ag, [2.22040369 2.22040369 0.     ...</td>\n",
+       "      <td>-0.204</td>\n",
+       "      <td>5.947</td>\n",
+       "      <td>[[0. 0. 0.] Ag, [2.2945515 2.2945515 0.       ...</td>\n",
+       "      <td>JVASP-12023</td>\n",
+       "      <td>17.478</td>\n",
+       "      <td>2.7025</td>\n",
+       "      <td>4.5320</td>\n",
+       "      <td>4.5323</td>\n",
+       "      <td>4.9101</td>\n",
+       "      <td>mp-567809</td>\n",
+       "      <td>1.2599</td>\n",
+       "      <td>(Ag, I)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>7.0316</td>\n",
+       "      <td>6.3127</td>\n",
+       "      <td>5.2274</td>\n",
+       "      <td>[[0.         2.06587432 0.88869064] Zr, [1.814...</td>\n",
+       "      <td>-1.768</td>\n",
+       "      <td>37.120</td>\n",
+       "      <td>[[0.         2.085838   0.88566666] Zr, [1.819...</td>\n",
+       "      <td>JVASP-12027</td>\n",
+       "      <td>54.633</td>\n",
+       "      <td>2.2441</td>\n",
+       "      <td>6.0366</td>\n",
+       "      <td>5.5260</td>\n",
+       "      <td>4.6886</td>\n",
+       "      <td>mp-570157</td>\n",
+       "      <td>1.8723</td>\n",
+       "      <td>(Zr, Br, N)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>4.6738</td>\n",
+       "      <td>4.7460</td>\n",
+       "      <td>4.7722</td>\n",
+       "      <td>[[1.41349448 4.71501305 5.06256213] In, [0.289...</td>\n",
+       "      <td>-0.830</td>\n",
+       "      <td>9.047</td>\n",
+       "      <td>[[8.49448596 4.73948454 6.27818672] In, [0.290...</td>\n",
+       "      <td>JVASP-12028</td>\n",
+       "      <td>16.378</td>\n",
+       "      <td>3.7113</td>\n",
+       "      <td>3.6685</td>\n",
+       "      <td>3.7637</td>\n",
+       "      <td>3.7977</td>\n",
+       "      <td>mp-570219</td>\n",
+       "      <td>2.3104</td>\n",
+       "      <td>(In, Br)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>5.0636</td>\n",
+       "      <td>5.0798</td>\n",
+       "      <td>4.9797</td>\n",
+       "      <td>[[1.50785766 1.02477434 2.93571664] Y, [ 7.555...</td>\n",
+       "      <td>-1.473</td>\n",
+       "      <td>7.687</td>\n",
+       "      <td>[[1.646224   1.11881123 3.20510836] Y, [ 8.247...</td>\n",
+       "      <td>JVASP-12033</td>\n",
+       "      <td>12.578</td>\n",
+       "      <td>2.8863</td>\n",
+       "      <td>5.5443</td>\n",
+       "      <td>5.5399</td>\n",
+       "      <td>5.5646</td>\n",
+       "      <td>mp-571442</td>\n",
+       "      <td>2.6760</td>\n",
+       "      <td>(Y, I)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>103</th>\n",
+       "      <td>2.8447</td>\n",
+       "      <td>2.9459</td>\n",
+       "      <td>2.7976</td>\n",
+       "      <td>[[1.17206677 8.41802227 0.93781225] Al, [0.259...</td>\n",
+       "      <td>-2.430</td>\n",
+       "      <td>73.973</td>\n",
+       "      <td>[[0.2515101  8.52548747 0.940367  ] Al, [0.057...</td>\n",
+       "      <td>JVASP-12038</td>\n",
+       "      <td>110.656</td>\n",
+       "      <td>6.9515</td>\n",
+       "      <td>2.4188</td>\n",
+       "      <td>2.4769</td>\n",
+       "      <td>2.3750</td>\n",
+       "      <td>mp-625055</td>\n",
+       "      <td>5.1686</td>\n",
+       "      <td>(Al, H, O)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>4.9033</td>\n",
+       "      <td>5.1118</td>\n",
+       "      <td>5.1243</td>\n",
+       "      <td>[[ 2.54192839 -1.33085318 -0.81347227] Bi, [4....</td>\n",
+       "      <td>-1.969</td>\n",
+       "      <td>38.960</td>\n",
+       "      <td>[[ 2.58162693 -1.32106185 -0.80748743] Bi, [4....</td>\n",
+       "      <td>JVASP-12051</td>\n",
+       "      <td>96.300</td>\n",
+       "      <td>4.4734</td>\n",
+       "      <td>3.6415</td>\n",
+       "      <td>3.7771</td>\n",
+       "      <td>3.7842</td>\n",
+       "      <td>mp-759883</td>\n",
+       "      <td>2.9829</td>\n",
+       "      <td>(Bi, O, F)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>115</th>\n",
+       "      <td>16.9750</td>\n",
+       "      <td>14.0779</td>\n",
+       "      <td>15.5189</td>\n",
+       "      <td>[[-1.3982931  -1.34418681 -3.44903549] Cu, [ 0...</td>\n",
+       "      <td>-0.716</td>\n",
+       "      <td>43.800</td>\n",
+       "      <td>[[-1.3943665  -1.40808459 -3.46870699] Cu, [ 0...</td>\n",
+       "      <td>JVASP-12059</td>\n",
+       "      <td>80.133</td>\n",
+       "      <td>0.0117</td>\n",
+       "      <td>17.6582</td>\n",
+       "      <td>21.6400</td>\n",
+       "      <td>18.3388</td>\n",
+       "      <td>mp-996956</td>\n",
+       "      <td>0.0087</td>\n",
+       "      <td>(Cu, H, O)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     epsilon_x opt  epsilon_y opt  epsilon_z opt  \\\n",
+       "75         21.0673        29.1228        17.6066   \n",
+       "80         13.8023        38.1854        35.5515   \n",
+       "83          6.3933         6.9466         6.3796   \n",
+       "92          6.0838         6.0838         6.5652   \n",
+       "95          7.0316         6.3127         5.2274   \n",
+       "96          4.6738         4.7460         4.7722   \n",
+       "99          5.0636         5.0798         4.9797   \n",
+       "103         2.8447         2.9459         2.7976   \n",
+       "108         4.9033         5.1118         5.1243   \n",
+       "115        16.9750        14.0779        15.5189   \n",
+       "\n",
+       "                                             structure  e_form  shear modulus  \\\n",
+       "75   [[3.1506963  4.30596127 3.56982179] As, [0.384...   0.025         19.993   \n",
+       "80   [[0.37213617 3.67987527 0.87369073] H, [1.4889...  -1.184         25.667   \n",
+       "83   [[ 0.92796672  1.82915421 10.16747299] O, [2.7...  -2.086         52.420   \n",
+       "92   [[0. 0. 0.] Ag, [2.22040369 2.22040369 0.     ...  -0.204          5.947   \n",
+       "95   [[0.         2.06587432 0.88869064] Zr, [1.814...  -1.768         37.120   \n",
+       "96   [[1.41349448 4.71501305 5.06256213] In, [0.289...  -0.830          9.047   \n",
+       "99   [[1.50785766 1.02477434 2.93571664] Y, [ 7.555...  -1.473          7.687   \n",
+       "103  [[1.17206677 8.41802227 0.93781225] Al, [0.259...  -2.430         73.973   \n",
+       "108  [[ 2.54192839 -1.33085318 -0.81347227] Bi, [4....  -1.969         38.960   \n",
+       "115  [[-1.3982931  -1.34418681 -3.44903549] Cu, [ 0...  -0.716         43.800   \n",
+       "\n",
+       "                                     structure initial          jid  \\\n",
+       "75   [[3.17888147 4.36479751 3.69558323] As, [0.381...  JVASP-11997   \n",
+       "80   [[0.34436223 3.69323659 0.87470146] H, [1.4990...  JVASP-12002   \n",
+       "83   [[ 0.938753    1.84002706 10.93783201] O, [2.8...  JVASP-12010   \n",
+       "92   [[0. 0. 0.] Ag, [2.2945515 2.2945515 0.       ...  JVASP-12023   \n",
+       "95   [[0.         2.085838   0.88566666] Zr, [1.819...  JVASP-12027   \n",
+       "96   [[8.49448596 4.73948454 6.27818672] In, [0.290...  JVASP-12028   \n",
+       "99   [[1.646224   1.11881123 3.20510836] Y, [ 8.247...  JVASP-12033   \n",
+       "103  [[0.2515101  8.52548747 0.940367  ] Al, [0.057...  JVASP-12038   \n",
+       "108  [[ 2.58162693 -1.32106185 -0.80748743] Bi, [4....  JVASP-12051   \n",
+       "115  [[-1.3943665  -1.40808459 -3.46870699] Cu, [ 0...  JVASP-12059   \n",
+       "\n",
+       "     bulk modulus  gap tbmbj  epsilon_x tbmbj  epsilon_y tbmbj  \\\n",
+       "75         34.556     0.6495          15.0619          14.9875   \n",
+       "80         78.478     0.0083          16.5818          61.5222   \n",
+       "83         75.067     2.4642           5.2402           5.8492   \n",
+       "92         17.478     2.7025           4.5320           4.5323   \n",
+       "95         54.633     2.2441           6.0366           5.5260   \n",
+       "96         16.378     3.7113           3.6685           3.7637   \n",
+       "99         12.578     2.8863           5.5443           5.5399   \n",
+       "103       110.656     6.9515           2.4188           2.4769   \n",
+       "108        96.300     4.4734           3.6415           3.7771   \n",
+       "115        80.133     0.0117          17.6582          21.6400   \n",
+       "\n",
+       "     epsilon_z tbmbj       mpid  gap opt    composition  \n",
+       "75           12.4788     mp-158   0.0221           (As)  \n",
+       "80           53.1874   mp-24242   0.0038  (H, O, F, Cu)  \n",
+       "83            5.3897  mp-510584   1.9202        (O, Mo)  \n",
+       "92            4.9101  mp-567809   1.2599        (Ag, I)  \n",
+       "95            4.6886  mp-570157   1.8723    (Zr, Br, N)  \n",
+       "96            3.7977  mp-570219   2.3104       (In, Br)  \n",
+       "99            5.5646  mp-571442   2.6760         (Y, I)  \n",
+       "103           2.3750  mp-625055   5.1686     (Al, H, O)  \n",
+       "108           3.7842  mp-759883   2.9829     (Bi, O, F)  \n",
+       "115          18.3388  mp-996956   0.0087     (Cu, H, O)  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'''\n",
+    "dropna(): Drop rows that contain any NaN (not a number) values.\n",
+    "'''\n",
+    "dft3d_df = dft3d_df.dropna()\n",
+    "\n",
+    "#Fetch the first 50 rows\n",
+    "dft3d_50 = dft3d_df.head(50)\n",
+    "\n",
+    "dft3d_50[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c-_0VEWkCnwh"
+   },
+   "source": [
+    "Here, we print out all the compositions in our select dataset of 50 materials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "gqFLu2zidKEU",
+    "outputId": "da764e75-41a1-41fe-9d7f-e2ef7d9228e1"
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install -U jarvis-tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Following function is required due to some issues in Jarvis with downloading data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_data():\n",
+    "    import requests\n",
+    "    import json\n",
+    "    import zipfile\n",
+    "    \n",
+    "    json_tag = \"jdft_3d-8-18-2021.json\"\n",
+    "    url = \"https://ndownloader.figshare.com/files/29204826\"\n",
+    "    tmpfile = \"tmp.zip\"\n",
+    "    \n",
+    "    response = requests.get(url)\n",
+    "    with open(tmpfile, \"wb\") as f:\n",
+    "        for d in response.iter_content(1024):\n",
+    "            f.write(d)\n",
+    "    return json.loads(zipfile.ZipFile(tmpfile).read(json_tag))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "js-QUJt4f2gn",
+    "outputId": "01a7c3a2-ee6a-4a91-ce52-ebad6d5899b7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['As', 'CuHOF', 'MoO3', 'AgI', 'ZrBrN', 'InBr3', 'YI3', 'AlHO2', 'BiOF', 'CuHO2', 'TiClO', 'VCuO4', 'ScBrO', 'ZnCu3H6Cl2O6', 'VOF3', 'ZnCl2', 'ScHO2', 'ZrMo2O8', 'BaCaI4', 'CaPbI4', 'YBr3', 'NdIO', 'Li2WS4', 'SnO2', 'SnO2', 'CoF2', 'GaS', 'RbPS3', 'BeF2', 'BeO', 'CO2', 'CaCl2', 'SrClF', 'SrBrF', 'SrCl2', 'CaCl2', 'CaClF', 'NaHF2', 'Bi2SO2', 'BrF5', 'IF7', 'AsF3', 'KSc2F7', 'CClF3', 'K2MgF4', 'LiMgP', 'H4BrN', 'NaHS', 'SrAl2Te4', 'AgAsF6']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from jarvis.db.figshare import data\n",
+    "from jarvis.core.atoms import Atoms\n",
+    "\n",
+    "dft_3d = read_data()\n",
+    "\n",
+    "comp_list = []\n",
+    "for indx, d in dft3d_50.iterrows():\n",
+    "  entry = next(j for j in dft_3d if j[\"jid\"] == d[\"jid\"])\n",
+    "  comp = Atoms.from_dict(entry['atoms']).composition.reduced_formula\n",
+    "  comp_list.append(comp)\n",
+    "\n",
+    "print(comp_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EACr0qhNDQ51"
+   },
+   "source": [
+    "Here, we filter out the feature vector to only include single scalar-values properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "FsH2HKwWCEe0",
+    "outputId": "d23135e0-8c6c-467f-e5e3-a0d005efb555"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 2.10673e+01,  2.91228e+01,  1.76066e+01,  2.50000e-02,\n",
+       "         1.99930e+01,  3.45560e+01,  6.49500e-01,  1.50619e+01,\n",
+       "         1.49875e+01,  1.24788e+01,  2.21000e-02],\n",
+       "       [ 1.38023e+01,  3.81854e+01,  3.55515e+01, -1.18400e+00,\n",
+       "         2.56670e+01,  7.84780e+01,  8.30000e-03,  1.65818e+01,\n",
+       "         6.15222e+01,  5.31874e+01,  3.80000e-03],\n",
+       "       [ 6.39330e+00,  6.94660e+00,  6.37960e+00, -2.08600e+00,\n",
+       "         5.24200e+01,  7.50670e+01,  2.46420e+00,  5.24020e+00,\n",
+       "         5.84920e+00,  5.38970e+00,  1.92020e+00],\n",
+       "       [ 6.08380e+00,  6.08380e+00,  6.56520e+00, -2.04000e-01,\n",
+       "         5.94700e+00,  1.74780e+01,  2.70250e+00,  4.53200e+00,\n",
+       "         4.53230e+00,  4.91010e+00,  1.25990e+00],\n",
+       "       [ 7.03160e+00,  6.31270e+00,  5.22740e+00, -1.76800e+00,\n",
+       "         3.71200e+01,  5.46330e+01,  2.24410e+00,  6.03660e+00,\n",
+       "         5.52600e+00,  4.68860e+00,  1.87230e+00],\n",
+       "       [ 4.67380e+00,  4.74600e+00,  4.77220e+00, -8.30000e-01,\n",
+       "         9.04700e+00,  1.63780e+01,  3.71130e+00,  3.66850e+00,\n",
+       "         3.76370e+00,  3.79770e+00,  2.31040e+00],\n",
+       "       [ 5.06360e+00,  5.07980e+00,  4.97970e+00, -1.47300e+00,\n",
+       "         7.68700e+00,  1.25780e+01,  2.88630e+00,  5.54430e+00,\n",
+       "         5.53990e+00,  5.56460e+00,  2.67600e+00],\n",
+       "       [ 2.84470e+00,  2.94590e+00,  2.79760e+00, -2.43000e+00,\n",
+       "         7.39730e+01,  1.10656e+02,  6.95150e+00,  2.41880e+00,\n",
+       "         2.47690e+00,  2.37500e+00,  5.16860e+00],\n",
+       "       [ 4.90330e+00,  5.11180e+00,  5.12430e+00, -1.96900e+00,\n",
+       "         3.89600e+01,  9.63000e+01,  4.47340e+00,  3.64150e+00,\n",
+       "         3.77710e+00,  3.78420e+00,  2.98290e+00],\n",
+       "       [ 1.69750e+01,  1.40779e+01,  1.55189e+01, -7.16000e-01,\n",
+       "         4.38000e+01,  8.01330e+01,  1.17000e-02,  1.76582e+01,\n",
+       "         2.16400e+01,  1.83388e+01,  8.70000e-03]])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Form feature vector from the scalar properties in the dataframe\n",
+    "scalar_cols = [col for col in dft3d_50.columns if col not in ['structure', 'structure initial', 'jid', 'mpid', 'composition']]\n",
+    "\n",
+    "feature_vect = dft3d_50[scalar_cols].to_numpy()\n",
+    "\n",
+    "feature_vect[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "svC874oHDb5w"
+   },
+   "source": [
+    "## Machine Learning Models Implemented in Sci-kit Learn\n",
+    "\n",
+    "``sci-kit learn`` is a Python package that faciliates the implementation of several machine learning models for dimensionality reduction, clustering, classification, regression, and more."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ZaGVRxi0o6Ko",
+    "outputId": "5ee4bfbe-c74c-4e1f-aa77-e2322ace2a91"
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install -U scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "svLOsMPEW00E"
+   },
+   "source": [
+    "Before performing K-means clustering, the data is pre-processed such that each feature has a mean centered at zero and a standard deviation of 1.\n",
+    "\n",
+    "**Try modifying**\n",
+    "\n",
+    "Run the K--means clustering on the un-scaled feature vector ``feature_vect`` instead to see what happens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "U256lcmBX4lN",
+    "outputId": "b420f1e8-8a1d-4bd4-85e5-dc011db7d504"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean:  [-1.33226763e-17  5.44009282e-17  1.47659662e-16  7.75768338e-17\n",
+      "  2.04281037e-16  3.33066907e-18  1.84297022e-16 -2.77555756e-17\n",
+      " -5.10702591e-17 -3.88578059e-17  1.53210777e-16]\n",
+      "std. deviation:  [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.cluster import KMeans\n",
+    "from sklearn import preprocessing as pp\n",
+    "\n",
+    "'''\n",
+    "Scale feature vector: pre-processing step such that features have zero mean and \n",
+    "unit variance\n",
+    "''' \n",
+    "scaler = pp.StandardScaler().fit(feature_vect)\n",
+    "\n",
+    "feat_vec_scale = scaler.transform(feature_vect)\n",
+    "\n",
+    "print('mean: ', feat_vec_scale.mean(axis=0))\n",
+    "print('std. deviation: ', feat_vec_scale.std(axis=0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zbl03YqbYirE"
+   },
+   "source": [
+    "Run the K-means clustering and output the cluster labels for each sample in the dataset.\n",
+    "\n",
+    "**Try modifiying**\n",
+    "\n",
+    "Change the number of cluster! ``K``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "XtbGanGNpSAY",
+    "outputId": "c6f40e63-2eec-474d-8702-2aabaefa8906"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3 3 2 2 2 2 2 0 2 3 3 3 2 3 2 2 0 2 2 2 2 0 2 2 2 1 2 2 0 4 0 0 0 0 0 0 0\n",
+      " 0 2 2 2 0 0 0 0 2 2 2 2 2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# Stochastic output\n",
+    "\n",
+    "#Fit K-means model\n",
+    "\n",
+    "K = 5; #CHANGE the number of clusters generated\n",
+    "kmeans = KMeans(n_clusters=K).fit(feat_vec_scale) #CHANGE to the unscaled/un-whitened feature_vect to see what happens!\n",
+    "lbl = kmeans.labels_\n",
+    "centers = kmeans.cluster_centers_\n",
+    "y_kmeans = kmeans.predict(feat_vec_scale)\n",
+    "print(y_kmeans)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7QFv4XsNS7kb",
+    "outputId": "26715837-b738-485e-d51f-1d5fb8a45af2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated Compound Cluster #1\n",
+      "['AlHO2' 'ScHO2' 'NdIO' 'BeF2' 'CO2' 'CaCl2' 'SrClF' 'SrBrF' 'SrCl2'\n",
+      " 'CaCl2' 'CaClF' 'NaHF2' 'AsF3' 'KSc2F7' 'CClF3' 'K2MgF4']\n",
+      "mean feature values of the cluster:\n",
+      "[{'epsilon_x opt': -0.5132547831730443}, {'epsilon_y opt': -0.45557719589338685}, {'epsilon_z opt': -0.4141502475546219}, {'e_form': -0.9467337547733757}, {'shear modulus': -0.05522530984902496}, {'bulk modulus': -0.06018701692796912}, {'gap tbmbj': 1.109461430619794}, {'epsilon_x tbmbj': -0.4511823847700216}, {'epsilon_y tbmbj': -0.36064511170660224}, {'epsilon_z tbmbj': -0.30576088850794414}, {'gap opt': 1.134001290054098}]\n",
+      "\n",
+      "\n",
+      "Generated Compound Cluster #2\n",
+      "['CoF2']\n",
+      "mean feature values of the cluster:\n",
+      "[{'epsilon_x opt': 5.118080483232208}, {'epsilon_y opt': 5.176294061860992}, {'epsilon_z opt': 5.821624635010576}, {'e_form': 0.24850991676223486}, {'shear modulus': 0.6453762819050016}, {'bulk modulus': 2.169974828558438}, {'gap tbmbj': -1.4111669293016793}, {'epsilon_x tbmbj': 4.325172905340975}, {'epsilon_y tbmbj': 5.546947827501139}, {'epsilon_z tbmbj': 6.202183200667313}, {'gap opt': -1.3897437533069272}]\n",
+      "\n",
+      "\n",
+      "Generated Compound Cluster #3\n",
+      "['MoO3' 'AgI' 'ZrBrN' 'InBr3' 'YI3' 'BiOF' 'ScBrO' 'VOF3' 'ZnCl2'\n",
+      " 'ZrMo2O8' 'BaCaI4' 'CaPbI4' 'YBr3' 'Li2WS4' 'SnO2' 'SnO2' 'GaS' 'RbPS3'\n",
+      " 'Bi2SO2' 'BrF5' 'IF7' 'LiMgP' 'H4BrN' 'NaHS' 'SrAl2Te4' 'AgAsF6']\n",
+      "mean feature values of the cluster:\n",
+      "[{'epsilon_x opt': -0.21861565532573934}, {'epsilon_y opt': -0.24059684133801615}, {'epsilon_z opt': -0.17121179568149048}, {'e_form': 0.4580747385577374}, {'shear modulus': -0.2581960243238025}, {'bulk modulus': -0.2990263042625242}, {'gap tbmbj': -0.36910729873274156}, {'epsilon_x tbmbj': -0.2505664814691818}, {'epsilon_y tbmbj': -0.2564644402930429}, {'epsilon_z tbmbj': -0.19708947721502657}, {'gap opt': -0.3918272317881384}]\n",
+      "\n",
+      "\n",
+      "Generated Compound Cluster #4\n",
+      "['As' 'CuHOF' 'CuHO2' 'TiClO' 'VCuO4' 'ZnCu3H6Cl2O6']\n",
+      "mean feature values of the cluster:\n",
+      "[{'epsilon_x opt': 1.5460966069354574}, {'epsilon_y opt': 1.4686644814695633}, {'epsilon_z opt': 0.9422520388468436}, {'e_form': 0.7066357979266257}, {'shear modulus': 0.28342763572201696}, {'bulk modulus': 0.43293069655804395}, {'gap tbmbj': -1.3749711857536084}, {'epsilon_x tbmbj': 1.6406430983249498}, {'epsilon_y tbmbj': 1.2072729367481736}, {'epsilon_z tbmbj': 0.6849559309443248}, {'gap opt': -1.387339662182166}]\n",
+      "\n",
+      "\n",
+      "Generated Compound Cluster #5\n",
+      "['BeO']\n",
+      "mean feature values of the cluster:\n",
+      "[{'epsilon_x opt': -0.4985765556070252}, {'epsilon_y opt': -0.44352794159575876}, {'epsilon_z opt': -0.39722621949893017}, {'e_form': -1.2505278304491392}, {'shear modulus': 5.250759493766172}, {'bulk modulus': 3.970117173766432}, {'gap tbmbj': 1.506400920957915}, {'epsilon_x tbmbj': -0.4353848207716034}, {'epsilon_y tbmbj': -0.35218821306543263}, {'epsilon_z tbmbj': -0.2954181626154681}, {'gap opt': 1.7572691120259651}]\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "# Stochastic ouput\n",
+    "\n",
+    "#Print contents of each cluster\n",
+    "import numpy as np\n",
+    "\n",
+    "for k in range(K): #For each generated cluster\n",
+    "    pos= [n for (n,m) in enumerate(lbl) if m==k] #Get the indices in the labels vector which point ot that cluster\n",
+    "    compGrp = np.array(comp_list)[pos]\n",
+    "    print('Generated Compound Cluster #{}'.format(k+1))\n",
+    "    print(compGrp)\n",
+    "    print('mean feature values of the cluster:')\n",
+    "    print([{f:m} for f,m in zip(scalar_cols, centers[k])])\n",
+    "    print('\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XW_F_bvfY4mL"
+   },
+   "source": [
+    "Here, we will use principal component analysis (PCA) primarily as a way to visualize our \"high-dimensional\" data (11 total features) in two dimensions. \n",
+    "\n",
+    "**Try modifying**\n",
+    "\n",
+    "Perform the PCA on the feeature vector first and then apply the K-means clustering algorithm to the principal component vectors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 297
+    },
+    "id": "HSYvic0kvyXA",
+    "outputId": "7480cd03-d894-47a2-de1e-842898f6270d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PCA(n_components=2)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEGCAYAAABsLkJ6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxEElEQVR4nO3dd5hU5dnH8e89bSu9V+lNigIiFtSI3ajEWKJGE40xMajvaxJ9NYk9do0mpmkSg9g1tmAsQVFQVKoo0uvSYSnby7T7/WNmYZed3Z2FmTmzzP25rrlgz5w957eLnnvOc54iqooxxpjM43I6gDHGGGdYATDGmAxlBcAYYzKUFQBjjMlQVgCMMSZDeZwO0BwdO3bUPn36OB3DGGNalAULFuxU1U77b29RBaBPnz7Mnz/f6RjGGNOiiEhBrO3WBGSMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgKQAhrchPrnoeE9Tkcxxpi9WlQvoJZGw+Vo0fXgnwfiA/WjuZcgrW5FRJyOZ4zJcHYHkERa8hvwzwWqQUsjf1a+jFa85HQ0Y4yxApAsGq6AqumAf783KqHin45kMsaY2qwAJItWNvxeuDh1OYwxpgFWAJLF1R5cHWK9Ab5jUh7HGGP2ZwUgSUQEaXMPkM2+X7MXJB9p9XMHkxljTIT1AkoiyToBOryElv8DggXgG4PkXYm4uzodzRhjrAAkm3iHIW0fdTqGMcbUY01AxhiToRwtACLiFZFHRWS1iGwUkXZO5jHGmEzidBPQn4GtwECHcxhjTMZxrACISFfgWGCEqqpTOYwxJlM52QQ0HFBghoisEJHnRSRv/51E5BoRmS8i8wsLC1Of0hhjDlFOFoDOwErgdGAYsB24Y/+dVPUpVR2rqmM7daq3pKUxxpgD5GQB2AOUq2q1qoaAN4GhDuYxxpiM4mQBmA2cICJ9ol+fCcxxLo4xxmQWxx4Cq2qJiPwIeEtEvMDnwM+cymOMMZnG0W6gqvoBMMrJDMYYk6lsJLAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToawAGGNMhrICYIwxGcoKgDHGZCgrAMYYk6GsABhjTIayAmCMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToawAGGNMhrICYIwxGcoKgDHGZCgrAMYYk6GsABhjTIayAmCMMRnKCoAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAxhiToRosACLSQUR+JyLPi8hVIiK13luamnjGGGOSpbE7gKlAIfAicBrwvojkR9+TBr/LGGNMi+Bp5L2+qnp29O9vi8jPiBSBMwFNfjRjjDHJ1FgB8IpItqpWAajqn0WkDHgbyE5JOmOMMUnTWBPQX4Fja29Q1anAc1gTkDHGtHgN3gGo6qMNbH8KeCppiYwxxqSEdQM1xpgMlRYFQERuEpFvnM5hjDGZxPECICLHAZc6ncMYYzJNkwVARJ6MsS0hzwBEpCPwGPDTRBzPGGNM/OK5A5hQ+wsR8QFnHOyJoyOLnwFuBrY3st81IjJfROYXFhYe7GmNMcZENTYVxLUishjoKyJfR1+LgQ3AtASc+0bgM1X9uLGdVPUpVR2rqmM7deqUgNMaY4yBxgeCvQC8C9wH3Fpre5GqFifg3H2B00TkcsAL9BSRT1R1QhPfZ4wxJgEaGwdQDBQDl4pIV6AbkQFgHUQEVV14MCdW1etr/i4ifYC37eJvjDGp09gdAAAi8jBwCbAWCEU3K3ByEnMZY4xJsiYLAHA+0F9Vq5MVQlXXA8OTdXxjjDH1xdMLaCOQlewgxhhjUiueOwCAt6I9gPZS1RuSkMcYY0yKxFMA/pn0FMYYY1KuyQKgqs+IyECgn6q+H+0RZIwxpoWLZyqIXwLPA3+LbuoCvJLMUMYYY5IvnofAVwPHAeUAqvoV0DOZoYwxxiRfPAWgUlUDNV+ISB6QtC6hxhhjUiOeAvC6iDwC5IjIhUSmh3ghubGMMcYkWzwPge8Rke8CbYjMAvpnVX0p6cmMMcYkVVzjAFT1NeC1JGcxxhiTQvH0ArpARJaLSLGIlIhIqYiUpCKcMcaY5InnDuAR4BxgiaqGk5zHGGNMisTzEHgndvE3xphDTjx3AKuAh0Vkdu2Nqvp6ciIZY4xJhXgKQBXQnkgzUA0FrAAYY0wLFk830CtTEcQYY0xqxdMLqKuIvCoi26Ovf4lI91SEM8YYkzzxPASeArwFdI++3ohuM8YY04LFUwB6q+pzqhqKvp4HeiU7mDHGmOSKpwBsEpFLRcQVfV0KbE52MGOMMckVTwG4ErgA2B59XRDdZowxpgWLpxfQZuD8FGQxxhiTQvH0AhomItNEZJOIrBKRP4tI+1SEM8YYkzzxDAR7EbgXuAjwAVcBU4FvJzGXMcZkvK07ivn39K/ZubuUo47oy7fGD8LrdSfs+PFOB12zBnAl8JiI/CRhCYwxxtQz58t1/PrhtwiGwgSDYT7+YhUvvDmXv9x7CTnZvoScI56HwAtE5DQRaR999QB2ikg7awoyxpjEC4XC3P37d6iqDhIMRubhrKwKsGHLHl57d1HCzhPPHcC3oq/9LSQyJ1C/hKUxxhjD2g07CQSC9bb7/UE+/HQZ3//OuIScJ55eQH0TciZjjDFxyfJ5CKvGfi/Lm7DzNFkARCQHOA/oBkjNdlX9XcJSGGOM2atX93Z06diaDVt2U7sOZGd5Of+MIxJ2nnieAbwLnAu0BVrVepkmVJZXMX3qTF6473UWfvA14bCtqWOMaZqIcP8tk2jfNo/cHB/ZWV58Xg+nHD+EUycMTdh54nkG0EVVT0rYGTNEwdKN3HjC7QT8QfwV1fhys+g3ojcPfXA7WTlZTsczxqS53t3b89qTP2H+1wXs3lPOyKE96NmtXULPEc8dwFwRGZ3Qs2aAey95nLI9ZVSVVREOK1VlVaxetI5//W6a09GMMS2Ex+1i/JF9Oevk4Qm/+EOc3UCBz0SkJPoqFZGShCc5hOzcsptNq7ay/zMcf2WA96d87EgmY4zZXzxNQNcDI4DVqg08ls4wFaWVzHv3S/zVAcaefgTtOrepu4P9mowxLUA8BWAnsM4u/hHz3l/E3Rc8grhcqCrhYIhrHr6c8yafuXefjj060KN/VwqWbqxTC3zZXk674sQ6x6ssq2TqXa/y4fOfgCrfuuR4rrjzIvJa56bqRzLGZChp6rouItOAUmB+7e1OdAMdO3aszp8/v+kdk6S8pILvdb+GqorqOtt9OT7+PO8BDhu2b52cdd9s4Ocn3k7QH6SqopqcvGwOO7wXj8y4Y+9D4HA4zORxt1CwZBOB6gAA3iwPPQZ2569fPoTbnbg5P4wxmUtEFqjq2P23x3MHUHPFzfiun19MW4C4pN72oD/I9GdncfX9l+3d1nd4b14o+AszX/2CnZt2MXjcAMacOhKXa99jlwXTv2bzyq17L/4Ageog2wt2MPedLznmnHr/XsYYkzDxjAS+C0BE8qNflyXixCKSDbwN9AVCwBRVvS8Rx04Wf5WfWHdMGg5TVV5Vb3tOfg5nXBlrFo2IVQvWUl3pr7e9srSK1QvXWQEwxiRVPOsBDBGRecBi4BsRmSciiRqJ8KCq9gdGAReLyBEJOm5SjD39CMKh+oO5snKzmHD++GYfr2vfzmTl1J/VLzs/m659Ox9QRmOMiVc83UD/DvxcVfuqah/gxui2g6KqVao6Pfr3SmA10OVgj5tMnXp24Io7LyIrx4cr2hSUnZfFcd85mpEnDmv28Y7/zjiy87L2HgtAXEJWjo8JFzS/oBhjTHPE8xB4maoObWrbQYUQ6UJkdtHDVbWoof2cfghcY9XCtUyfOhN/lZ8TLjiGIyeOQKT+s4F4bF27nQd/8AQr5q4GYODoftw89Xp6DuyWyMjGmAzW0EPgeArAq8Ai4LnopsuAMar63QQFywKmA0+r6pQY718DXAPQu3fvMQUFBYk4bdopLy4HIK9NnsNJjDGHmoYKQDxNQFcDHYA3gNeBjsCPEhTKB7wGvBvr4g+gqk+p6lhVHdupU6dEnDYmVWXt1wUs/WIlAX+g6W9IsLw2eXbxN8akVIO9gKLNMj1VdQHw81rbjySyNvBBEZFcIkVlhqo+eLDHOxgFyzZx2zkPsGd7ES63CxHh5inXcex5RzkZyxhjkqqxO4AHgJExto8Efp+Ac48DTgKuFJHl0df9CTjuXiW7S/nTDU9zcfcfc1mfa3nunlfxV9f9dB8MBLnp5LvYtm47VeXVVJRUUl5cwX2XPs7m1VsTGccYY9JKY+MATgR+HGP788BvD/bEqvoxkLR5kf1Vfq4/+lZ2bNxF0B9ZWu2lB97km9kreOC93+zdb+EHi6murK43fU8oGOLdv3/I1Q98P1kRjTHGUY3dAaiq1luUMrqtPHmREmPmK5+ze3vx3os/QHWlnyWzl7Ni/pq924oLS9Bw/QfhwUCIXVv2pCSrMcY4obECsEFExuy/UUSOAQqTFykxlny2nKqy+qNzNaysrFUARpwwlFAwVG+/7PwsjjrzyKRmNMYYJzVWAG4AXhWRW0VkYvT1K+BV4FepiXfgug/ohi/GKFu3x03XPvt6E3Xt05kzr55Idt6+1qisHB+9BvdgwnePTklWY4xxQqPjAESkMzAZOBzIBb4BnlLV1amJV1dzBoIV7yzhigHXUVFSuXeby+2iU68OPLPqiTozbaoqn74+h2l/eZ/K8mpOvuQ4zvrxKbZ0ozHmkHDAA8HSSXNHAq/+ch0PXvEEm1ZtBVWGHTuYW569gU49OxxUjs2rt1K4aRdz3/mSD56dScAf5LhJ4/jRfZfSrkvbgzq2McYkWkYWgBpFhcV4vB7y2x7cQKs924u4fdJDrP1qPcFAqM7EcG6Pm/bd2vKPpY+Tk5d9UOcxxphEOpiRwC1e205tDvriD3DbuQ+wasFa/FWBerOChoIhSneX8dGLsw/6PMYYkwoZUQASYdOqraz/ZmPMHkM1qsqrWT53VQpTGWPMgWtsKojzG/tGVX098XHSV3FhCW6vGyob3ifSe6h76kIZY8xBaGwk8DmNvKdEJobLGP1GHUYoWH8xmNo8Pg+n/7DhFcCMMSadNFgAVPXKVAZJdzl52Vz9wGX8/ZbnqY4uCi8uQcOK2+Oi/xF9+eXTP6N1h4xfOtkY00I0uSawiPQgMhagC7B31RNVvSqJudLSpOvOpPfQnrz22DR2by3i6G+P4exrTiGvdS65rXKcjmeMMc3SZAEAXiKyePv3iSwHORoYmMxQ6Wz0xBGMnjjC6RjGGHPQ4ukF1CE6X38x8BbwG2BQUlMZY4xJunjuAGrmQ1gEXAC8C7RLVqCWprqymv9O+ZjZb82jbafWnDv5DIaNt/pojEl/8RSAe0SkHXA3kYv/E0TuAjJeVUU1NxzzK7as2U51RTUiwqdvzOEnj1zBOT893el4xhjTqCabgFR1iqruUdVVqjpAVTup6pOpCJfu3nt6BlvWbNvbK0hVqa7w8+QvplJR2siAAWOMSQNNFgARGSYi00Rkk4isEpE/iUj7VIRLhZ2bd7Fi/hoqy5p/wf709TlUV/jrbff4PCyfYyOCjTHpLZ4moBeBe4GLiCwGfxUwFfh2EnMlXXlJBfd+7zEWfbwEr89DKBDi+7dfwPf+7ztxH6NNx9h9/kOhMHkJmHvIGGOSKZ4CgKq+Ev1rJfCYiPwkeZFS46Ef/JFFHy0hUB0gUBVZKP75375GjwHdmPDd8XEd49zJZzDnnS/3NgEBiAjtOrdh0Jh+Ccu6eMd2/jj3c1bu2sXQjp340ZFj8IdCtM3JYUiHjohI0wdJc+XBCt7e+h/m716Az5XFKZ2/xYmdT8AlNl2VMckSTwFYICKnATXzMOcAO6MPhkVVdyctXZKU7C5l3nuLCFQH6myvKq/m5YffirsAjDrxcH5w10VMue0lPD4PGlZad2zFfe/++qAvyltLS3ly4Tw+WreGzaWlhKPTdhcUF/HemlXkerwo0LN1a54+73x6tGp9UOdzUnWomruW3MMu/26C0WWoX9j4MqvKVnNN/6sdTmfMoSueAvCt6Gt/C4nMCZS4j7opUrq7DLfHRaC6/nt7thU161gX/uJczrjqZJZ+vpJW7fMZevTAg774by4p4dsvTqU8ECAYjj3/UEUwUrzW7NnNlW+9xvuX/bDF3gl8vusLigJFey/+AP6wn7m753Nuj3Pomt3FwXTGHLqaLACq2jcVQVKpa5/OeLO8VJXXrQAut4vRpzR/lG+rdvkcfdboRMXjsS9mU+r37/3U35iwKltKS1m+aydDO3Zqcv90tLRkOdXh+g/TXeJibdk6KwDGJEmDDawicl70zytivVIXMfHcHjeT/3AVWbn7Fo13e93kts7h+7dd6GCyiM82bYjr4l/DLUJRZcvtdtopqxNucdfbLgjtfG1TH8iYDNHYHcDRRKZ+OCrGe0qkJ1CLNfHSCXTu1ZGXH3qT7QWFHHHScC66+byDXi84ETrm5LKtrCzu/QPhMCO6dE1iouQ6qfMJTN8+nZDuW2zHhYtW3lYMbmWjqo1JlibXBBaRrgCqui36dWfAVfN1Kh3omsAtzdsrl/N/H7xPZTBYZ7sLCBP5xB+K/rvleDz88pjj6dOuHQVFRQzt2IlxPXq2uOcBy0qW8+Sav1MeKkc1TO/c3kwecC0dsg6ZISfGOKahNYHjeQj8OvBToOaC3waYAhyXsHQtWFFhMdUVfjr3Tlx3zLMHDqaguIg/zZuDx+UiEAoxtntPbhx/LN3zWzFt5XKmr11Nh9xcJg0exgOzZ7GzopxgOIzb5WJA+w48/50LyfP5mj5ZmhjaegiPHfEwO6p34HP5aOez6aaMSbZ47gBWquqg/bYtU9WhSU0WQzrdAezcspv7Ln2c5V+sQtwu2nZqzc3PXMeoEw9P2DnK/H7W7N5F57x8urWKPejs6n+/wayCdQRr/Tv63G4uGT6SO048OWFZjDEtV0N3APGMstklIsNrHehwGl0Z99Cnqtw08S6WzF5BwB/EX+lnx4ad/Obb97Nt/Y5mH29XRQVzN29ic2lJne35Ph+junZr8OLvD4WYVbC+zsW/Zvuby5c1O4cxJrPE0wR0A/CGiGwhsiJYL6BF9wI6WEtmL2fX5t2EQ3X76AcDQf7z1HR+dN9lcR3nq1lLefD+5yko3IV/bFfKDm/DcYf14Ykzv02O19vk96sqSuw7uJA2vn6xMcbEMw5gnogMAwYTKQArVTXGEKrMsWPjrlqLY+4T9IfYsjq+Z+NT73qFFx58g2BVkFwg+5s9eAa1ZvaP4c6ZH/LgKWc0eYwsj4fR3bozf8vmOmXA43JxWr8B8f0wxpiMFc9soFnA+cCp0ddkEfl5soOls8FH9ScUCNXb7va66TO8V5Pfv2NDIS8/+CahquDeOuLyh8ldWYJr6W7+vWI5/lD948fywCmn0zY7hxxPpJbner10ycvnluNPjPvnMcZkpniagN4GSoAlQHxXpUNczYRxn75RdzroUCDESw+8SZ/Dezc6n9CC6V/jctevvS5/mLzFuyk6vD1VwSA+d/3BUfvr27YdM394NW+tWMaa3bsY0bkrZw0cRJYnrnn+jDEZLJ6rRE8nevyku5umTEYVZrzwSZ3t/qoAD1/1J44+ezS+7NjdMHNb5SCu+m1I6oJwjocerVrTqhldOPN9Pi4bMap5P4AxJuPF0wvoaxEZmPQkLYzb7WbZnJUx3xMRln4e+z2Ao789hlgPEdTtInBMV+49+dQWN5DLHLjyYAUbKzZRGcroznXGAfHcARwDfCIiNf0bBVBVHZm8WOlvzVfr2b4udpfPcDiML7vhXjzZuVnc+/at3HbuA4TDYfyhEKFgiN6Tj+XP/3MZgzt0TFZsk0aC4SDPFjzP7J2f4RYPIQ1xateJXNTzAvsAYFIingIwIekpWqAZL37aQAdMcLndDDm68ZumEROG8sq2v7Noxjf4q/wcefJw8tokfxWx6mCQN1cs44O1a+iYm8tlI0YxvLPNtumE1za9wWc7vyCgQQLRqbA/2D6Ddt62nNb1VIfTmUzQYAEQkW6quhUavM5ltFAw1OBvZtJ1Z+ByNd265svyMu7MIxOcrGGVgQAXvPoi64v2UBkM4hLhrRXLuPukiVwwbHjTBzAJE9YwH+74CL/WnQbbH/bzztb3rQCYlGjsKlUz2+d/iPQE+k+t19uJOLmInCUi34jIChH5VSKOmSonfHc8vpz6D2q9WV7O/VnTffid8PKSxXsv/hBZS6AqGOSOj2dQGQg08d0mkUIawh9jDQSAsmD8M8EaczAaLACqWvMR5BeqOlJVR9R6HXT7v4jkAX8BTgEOB84UkcStqpJkw44ZzJk/Opms3CzEJbg9bnzZPn766BV06JaeE5m9u3plvRlGAdwu4avtKZ/cNaN5XV46Z3WO+V7fvD6pDWMyVjzPAB4Fmr9MVtPGAQtrTTP9L+AsIktNtgiTf38Vp1x+IrPfmIMny8PJ3zuenoO6Ox2rQW2ys2NuD6uSn6KZQ4v8xXy8Yyabq7bQP68fEzodT54nNyXnTjeX97mUP6z60947AUHwurxc0vtih5OZTBFPAVgkIoNVdUWCz90dqN2NphCo9+RURK4BrgHo3bt3giMcvMFj+zN4bH+nY8Tl8pFHMHtDQZ27AAE65ORyeKfYn0YTaUPFRu5b+gDB6EPPRUVf8Z+t73Ln4bdl5Lz/I9oM55YhN/HvLW+zpXIrffJ6c173c+iZ29PpaCZDxNsL6BMRqWkjSGQ30P1nLKv3MVRVnwKegsh00Ak4Z8aa0LsPPx07jj/Pm4PX7UYVWmdl8c/zzk9Jt8On102hMly192t/2E8wHOClja8wecBPk37+dNQ/vx83DrrB6RgmQ8VTAJI1qcw2oHaH907sW3Qmrc15ZyFvPvEOxTtLOW7SUUy67syUdOGMZe2e3Uz96ksKios4tmdvLh4+ktZZWQ3uf/24Y7hk+CgWbt1M2+wcxnbvgSsFF39/2E9B+YZ628MoXxctTvr5jTH1NdYNtBVwB5FmmVnA46qayLmA5gD/iC4xuRu4APhNAo+fFM/f+xov3v8G1RWRCVELlmzk/X9+zF+/fJjcVjkpzfLphgJ+8vabBEIhgqrM2byJpxctZNoll9Mxt+F29Y65uZzWP7WDu124IncZMe7hvK6mp742xiReY91A/wlUAY8Aw4F7EnliVS0Drgc+ApYC01V1ZiLPkWglu0t54d7X9l78ITL3z66te/jPU9NTmkVVuWn6e1QGg3sXhKkKBtldWcETcz9PaZZ4eFweRrc9Eo/UneDOK15O7GRjDY1xQmNNQMNV9QIAEZkLLAYS2ldfVacB0xJ5zEQqKypn5iufUbSjhFEnDaOyrAqPz4u/qm6feX+lnznvLOTCX5ybsmybS0sorq6qtz0QDvPB2jXcddLElGWJ15V9r6BweSFbq7YhRJp/BrcayKQeqfu9GWP2aawA7H1Aq6rVIlK/A/khbOnnK7jljN+iIcVf5ceX42PAkX0Jx5inX0To2D21vVhyvV7CDazn3JyZRFMpz5PHnYffxtrydWyv2kGv3J70aqTHi6oyf88CZhZ+QljDHN/xOMZ3GIdL4pnD0BjTlMYKwBARqVmkVoDc6Nc1vYBaJz2dQ8LhMHd99xEqS/d9wq4qr2bVgrXktc3DXxWosxykL8fLpOvPjPv43+zYzspdO+nfrj0ju3Q9oB447XNyGdutB3O3bCIY3pclx+PhB6NSN71Ec4kI/fP70T+/X5P7/m3t08zfs4DqcKTJbXXZGubunsv/DLzeJkszJgEaLACqmrEfs9Z+VUBlWf3mlepKP72H9qBt59ZsXrUVt8eNhpXJf7iKIeOafqhaEQhw1VuvsXjHdkQEVRjcoQPPTLqAVo303GnI42eczRVv/osNxUW4RAiEQpw3eCgXD9/XQ1dV2VpWSr7PR+us2APB0lFB+Qbm7ZlfZ7qE6nA1S0uWs7x0BUNbD3EwnTGHBls2qpnKiyv465cPs3Pzbkr3lDPgiD4NLvyyvwdnz2LR9m11lntcurOQu2fN4OFT47+DqNExN5f/XHI53xTuYGtpCcM7d6F7q303Zh+tX8uvPvwvxdXVhFU5vtdhPHramQ2OCE4ny0qWEY7R6aw6XM2S4qVWAIxJgIz9lN+YfqMOIyc/9kWycNMuLu19Lf6qAMPGD4r74g/wxrKl9db69YdCTFu5Am2gPb8pIsKIzl04rf/AOhf/5TsLmfzONLaXl1MVDOIPhfhkw3quefvNAzpPquV68nBL/c8nXvGS7813IJExhx4rADG4XC7ueO2X5LTKxu2t220xUB2krKicey76XbMv2v5w7GEUwXA44XNuP/3lAgL7FZtAOMziHdtZu2d3gs+WeEe1H4PEWDVNRBjf/mgHEhlz6LEC0IBhxwzmhYK/0rZj7GfdOzftYlsDK4I15LheveuNuhVgXPeeCR+Nu764iFCMAuV1udhSWprQcyVDjjuHXwz+X/I9+WS7ssl2ZZPrzuWGAZNp62vjdDxjDgn2DKAR+W3zyG+Xx66te2K+39w7gDtPnMh5Lz9HVTBIVTBItseDz+3mtyefkoi4dYzv0ZOv93veAJEmpyEdOyX8fMkwqNVA/nDk71hTtpawhhmQ3x+Py/6TNSZR7A6gCaf94KSYC7906NGebv2at5RirzZt+OiKH/Hz8cdxzqAh/M+4Y5hxxVX0a5f4MQRXjBpNvs+Hu9adRY7HwyXDRzU6TQREClthRTnl/tgLlqSSW9wMajWQIa0H28XfmASTA3346ISxY8fq/PnzU3pOf3WAW067h9VfrqOqvJqsXB9uj5tHZtzJgCP7pjRLc20tLeXxOZ8xs2AdbbKy+dGRY7hw2PBG+9B/UrCeW2f8l50VFaBwSr/+3D/xtAPqpmqMSQ8iskBVx9bbbgWgaarKlzO+YelnK+jQvR0nXnRsyid+S4XlOws5/5UXqKq1XoDP7WZstx48d/6FDiYzxhyMhgqA3VPHQUQYPXEEoyce+MJoJdVVLNq2jbbZ2bTPzqE8GGBAu/a441g8PlX+sXB+vZ5D/lCIhdu2sL5oD33apudSl8aYA2MFIAWeWjCPx76YjcfloiK6+Hq2x0O2x8tDp57OxL7psaLY2qI9DfYc2lxaYgXAmENM+nz8PER9tnEDv5/zGdWhEOWBAEpkSvzKYJA9VZXc8O7brNm9y+mYABzdoyfeGHck/lCIwR1aRs8hY0z8rAAk2TNfLayzBu/+/KEQzy3+KoWJGnblEWPI9fpwUbfn0PeGj2yy51AmqAhW8Oamf/ObxXdw/7KHmL974QGP4DYmHVgTUJLtrqxs9P2QKptLSxrdJ1U65eUx7ZLv88hnn/LpxgLaZGVz1ZFjuHR4IpZ/btmqQlXcseRu9vj3ENBIQV9Xvp7TupzCBb3OdzidMQfGCkCSnd5/IEsKd9TpWbO/jcXFFBQVcVjbtqkL1oCerdvw+BlnOx0j7cwq/IQif/Heiz9EJqZ7d9v7nNb1FFp7D9nZ0c0hzJqAkuyS4SPp0ao1WW53g/us3LWTSS8/R2FFeULPHValIhCwZooE+Lp4MX6tPzDO6/KypmytA4mMOXhWAJIsz+fjtyefikKMqc0iFCjz+7nxvXcSMlFbKBzm4dmfMPKvTzDqr08wYcrf+O+aVQd93EzWzts+5uR0YQ3bp3/TYlkBSIHbP/oAfyjU6IyfIVU+37SBs194lt9/8dlBne++T2cy5auFVAQChFTZUlrKje+/w5xNGw/quJns1K4T8bq8dba5cNHO145+eek9ItyYhlgBSLKiqkrWF8WeTG5/ClSHgjy5cB5LC5s302iNikCAF7/5ul7Po8pgkN/P+fyAjmmgd24vru57FTnuHLJd2fhcPnrl9uTmwb+w5SlNi2UPgZPM62q47b8h/mCIt1euYHCHjgTDYbI88f8zFZaXNzi19Lo4C5GJ7egORzGm3ZFsrNxErjuHLtnNmwzQmHRjBSDJ8nw+jut1GJ9sWB9zlG1sysyCtfzjy/kEwmFcIhzWpi2/nnASJ/dtfDH1rvkNr5bVq7XNo3+wPC4PffP6OB3DmISwJqAUuHzkEYSb0xNHhFW7dhEIh4FIb551RXv42Tv/ZtrK5Y1+a5bHw7Vjx8Uc0bt4xzYWbt3SrOzGmEOXFYAUeHrRgiaXfHSJ4HG5yHK7ESAYo2D4QyHu+2Rmk906rx0zjlyvt9726lCI+z+d2YzkxphDmTUBpcCKXTsbfM/ndnNU9x4c1+swFKV9Tg73fTKLUn91zP13VkQWec+JcYGvURUKUdbAYi4H+nDZGHPosQKQAv3ato8ssLIfn8vFWxdfxuBaSzRuLS3ljtCMBo+V6/U2+VA42+Mhy+PZO/NobR1z85qR3BhzKLMmoBT43/HHkr3fRTvH4+Hq0WPrXPwBurVqxVkDB+GJ0Yaf7XZzzZijmlxA3iXCD0eNJifGOScfdfQB/hTGmEONFYAUGN+zF3888xwOa9MWAVpnZfGzo47m58ccX2/fsCpel7teO3+W281Pxozj2rHxXcBvHH8slwwfRbbHQ47HS57Xyw3jjuHCYcMT8SMZYw4BtiRkigXDYdwiDQ4eemXJYu6aOaPOQC4XMLJLV16/+LJmn68yEGBXZQWdcvOaNZ7AGHPoaGhJSLsDSDGPy9XoyNGpX39ZbxRvGFi6s5DtZWXNPl+O10vP1m3s4m+MqceuCg4rrqri6UUL+GjdWjrk5rKzvP7DYgC3COWB2D17MpGqUhwoxuvykeexxWqMORBWABxUXFXF2S9MZVdlBdXRxdg9LhcukXoDx/J9WbYmb9SK0pX8be3T7PFHprYY0mowP+n/Y1p7WzmczJiWxZqAHPTMV1/WufhD5BmBqpIdXT/A63KR4/Hw49FjmfTy8wz+42OM/8dfmbJoIXsqK6huZKGZQ1FhdSGPrniMwupCghokqEGWlSznoeWP2LoHxjST3QE46OP1a+tc/Gvk+XxcNGw4m0tL6Nm6DWO6defn/31376piO8rLuXvWR/x21kd43W7OGzyUO086mWxPw4PDDhUfbv+IYLju7yxEiB3VhawtX0f//MbnSjLG7GMFwEGd8/Nhe/3twXCYS4aPpH/7DgBc+dZrMZeUDBOZ3uGtFcso8/v541nnJDmx87ZVbSdE/aIpCLv8u+iPFQBj4mVNQA666ogx9QZruUUY0K793os/wIqdDU8lAZEi8OG6NRSWJ3ZJyXQ0pNVgfC5fve0hDdEnt0/qAxnTgjlSAETkFRFZKyIrReQJydAVNcb16MmvJ5xEjsdLvs9HtsfDsE6d+fu536mzX7927Zs8ltftZmtZabKipo0TOh1PrjsXN/vWWfC5fIxtP5rO2Z0a+U5jzP6cagJ6FriYSAF6GzgXeMuhLI66dMQozh86jGWFhbTNyaFvjJ4+/zv+WBa+uSVmM1CNQCiUEb2Ecj253HX47byx+S2+LFpEtiuLiV1O5tQuE52OZkyL4/hIYBF5FFipqk82te+hMBL4QM1cv467Z30Uc1WvHI+HK0Ydyf8dd4IDyYwx6a6hkcCOFgARyQW+Bs5W1RUN7HMNcA1A7969xxQUFKQwYfoJhcOsK9rDA5/OYv7WzbTJyuaILl3J9XoZ1qkzk4YMo1VWltMxjTFpJOUFQEQ+ADrGeOssVd0Sbfd/EVimqnfFc8xMvgOIZXNJCZNefp6KgJ/KYJAcj5ccr4c3LrqMXm1s+UdjTERDBSBpzwBU9ZRGwgjwJFAU78Xf1HfnzBkUVVXuXWu4MhigOhTkto8/YMp533U4nTEm3aW8F5CIuIEpgB+4NtXnP5TMKlhXb6H5sCqzNxTYqFhjTJOc6AXUC7gcWAksi/YAnauqVziQpUXzuFx7F46vzR1jMRljjNlfyguAqq7HBqAlxDmDhvDmimX4a00n4XW5OHvg4EannDbGGLALcYv2qwknMahDR3K9XrI9HnK9Xga078AdJ37L6WjGmBbA5gJqwVpnZfHWxZcxb8tmVu/eRf927RnXo6d9+jfGxMUKQAsnIozr0ZNxPXo6HcUY08JYE5AxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKMeng24OESkEnJgOtCPQ+LJczrFsByZds6VrLrBsByJdch2mqvVWTGpRBcApIjI/1kx66cCyHZh0zZauucCyHYh0zVXDmoCMMSZDWQEwxpgMZQUgPk85HaARlu3ApGu2dM0Flu1ApGsuwJ4BGGNMxrI7AGOMyVBWAIwxJkNZAYiTiLwiImtFZKWIPCFpMOeyiJwlIt+IyAoR+ZXTeQBEJFtEPhCRNdHfVVrk2p+I3CQi3zidozYR8YrIoyKyWkQ2ikg7pzMBiMgPov+drRSRf4lIfhpkGi0iX9f6uoOIvBfN+J6ItE+TXL+M/nsuF5F3RaReX3wnWQGI37NAf2AoMAA418kwIpIH/AU4BTgcOFNERjuZqZYHVbU/MAq4WESOcDhPHSJyHHCp0zli+DNQDgwEegNFjqYBRKQLcAdwjKoOAnYA1zuc6VFgOnWvXw8Db0QzvgHcmSa5FgEjVXUI8AmQVh+IrADESVWnaUQIWAp0dTjSOGChqm5T1SDwL+AshzOhqlWqOj3690pgNdDF2VT7iEhH4DHgp05nqU1EugLHAndqLU7nAnxAHlDzqX8b4HcuDqjqL4Ax+22eCLwc/ftLOPD/QqxcqvqBqlZEv1yM89eNOqwANJOI5ALnAR87HKU7kU9jNQpJs/+4op8exwNznM4CEG22ewa4GdjucJz9DQcUmBFt0ns+epfnKFXdSKRgLhORvwNHEblTSTcdVLUIQFWLAUeagJrwfeBDp0PUZgWglmjb9aIYr+7R9wV4GnhWVVc4mxaA8H5f+xxJEYOIZAGvAr+u+R8zDdwIfKaqHzsdJIbOwErgdGAYkQJ1h6OJABFpQ6S58xjgfaAfcLKjoWLb/24pbf5fABCRnwEdgH86naU2WxKyFlU9paH3ohf/J4EiVb0rdakatI3IRFM1OkW3OU5EfMBrwLuqOsXhOLX1BU4TkcsBL9BTRD5R1QkO5wLYA5SrajWAiLwJ3ORooohTgWWquozIXUAZMBn4j7Ox6tkjIvmqWhYtWrudDlRDRK4ALgfOiDYhpw27A4iDiLiBKUTaPq91Ns1ec4CjRKSziHiAC0iD28toE9k04BNVvd/pPLWp6vWqOjj6QG4isCpNLv4As4ETRKRP9OszSY+ms7XAhFq9asYCyx3M05AZwMXRv3+PNPh/AUBErgF+DJwZbZpKKzYSOA7R/ynXErlFrzFXVa9wJlGEiJwDPEDk0+xzqnq3k3kAROQkIk0F62ptfkNVb3UkUAOi/6Zvq+pwp7PUEJFTgEeJ/Ht+Dvys5o7ASSJyA3AdECLSq+UaVS11MM/dwCQivaWWAL8g0jHjeaAPsB64TFUL0yDXM9G3q2r2i34ASQtWAIwxJkNZE5AxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkKCsAJmVEJBydFXGliLweHbATa78PRaTHARz/fhH5zgFmmyIiFzTw3ggR+Tg6G+x6EXlGRLodyHnSgYi0jY5MbWyfPBH5TETSdkFzc/CsAJhUqlDVIdEZG5cBt8faSVUnqurm5h5cVW9V1TcONmRt0fmM/g3crKr9gEHALKBnIs+TYm2BBguAiBwDrCIy7485hFkBME55HxgkIn1EpEBEnhORJSJyenTu+T7R10YReTV65/ChiOQAiMhRIvKFiKyK/tldRP4oIj+Mvr9eRP4pIl+LyGIRGR7dfmX0k/xyEZktIr2ayDkZ+LuqzgVQVb+q/kNV50U/Sf8reqzPRGRY9Bx3isjb0VxrROR/RGRqdL9ZNZO8NZKxp4hMj+7/31pzUU0RkZdEZIGIbBCRi2pCisjt0XmrVorIzdFtPxSRmdHXOolMVwxwPzAwevy/7f8Dq+rnqtqdyOhkcwizAmBSLjpR3FVEPklDZLrh+1T1cFV9f7/ds4DboqMni4FJ0bmGXgR+oqoDiUztHGtE4yuqOhL4LZER0xD5ND8gerxpRC7wjTkcmNvAe3cAX0WPdQswtdZ7ZcCJRKZ0eAh4IrrfZiKzyTaW8QlganT/Z4E/1Np/K3A08G3gHoBo01Ub4Egis4peKCKDa33PJCLrWHwvWkxuJTINxhBV/XETP785hFkBMKmUKyLLiQyT3wY8Ht2+TVWXNvA9O1S1Zu6ZJUSmwR4MbFXVrwBUdZGqbo3xvfOif04DahbLaQ9MlchqYNfR9FoFuY28dxLwXDTDLKCTiLSOvjc/Oo3DaiCgqjVZVgG1nx/EyjiBSIEj+ueJtfafHV3/oeZ3AXAGcCGRZrWvo8fvF31vsaruUdUqItOZtNhnFybxrACYVKp5BjBAVW9R1UAzvz8ESPTVHD6gMvr394B3iVxs/zeOY31DZPGdeNQ7lqruP2V3uIFz1s7YpOiskjXHcQE3RX+3Q1S1p6q+G+Pban+PMVYATIu0EugtIiMARGRQ9GHt/nKif15JZKk+iDwAfQcIsO8Td2OeAiZLZBlJRMQTbVsfDcwkurSkiBwPFKpqSTN/llgZP2XfzJYXE1lKsDHTgeskulaviBzRRC+lIqCziGSJOL+2tXGOrQdgWhxVrZLInP5Tow+F9wDfjbHryyLSAVgD1Mzc+hvgKyIXwZVE2uobO9cqEbkEeFAiC3rnE7lAvwfcBfwj2qy1B/jBAfw4sTLeAPxTRG4HNgI/bCLjiyIyCJgffb6yGbiokf2LRORf0XO+B1xd+30RGUdk1a/BRH7H76jqLw/gZzNpzmYDNYckEVkPjFXVnU5naUhLyGgObdYEZIwxGcruAIwxJkPZHYAxxmQoKwDGGJOhrAAYY0yGsgJgjDEZygqAMcZkqP8HtlqxUk8r5VMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot samples against first two principal components, colored by their cluster\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "from sklearn.decomposition import PCA\n",
+    "pca = PCA(n_components = 2)\n",
+    "pca.fit(feat_vec_scale)\n",
+    "print(pca)\n",
+    "comp_dim = pca.transform(feat_vec_scale)\n",
+    "plt.figure()\n",
+    "plt.scatter(comp_dim[:,0], comp_dim[:,1], c=y_kmeans) \n",
+    "plt.xlabel('Principal Component 1')\n",
+    "plt.ylabel('Principal Component 2')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_IvfS47uZjOm"
+   },
+   "source": [
+    "The principal components are linear combinations of the original features. Here, we plot out how each principal component weights the original features. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 370
+    },
+    "id": "gWBrKL0L1eO2",
+    "outputId": "f5503671-146d-4c6e-dadf-1c234a1e86ae"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],\n",
+       " [Text(0.0, 0, '0.0'),\n",
+       "  Text(0.2, 0, '0.2'),\n",
+       "  Text(0.4, 0, '0.4'),\n",
+       "  Text(0.6000000000000001, 0, '0.6'),\n",
+       "  Text(0.8, 0, '0.8'),\n",
+       "  Text(1.0, 0, '1.0'),\n",
+       "  Text(0, 0, ''),\n",
+       "  Text(0, 0, ''),\n",
+       "  Text(0, 0, ''),\n",
+       "  Text(0, 0, ''),\n",
+       "  Text(0, 0, '')])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAagAAAE9CAYAAABeGfYwAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAxpUlEQVR4nO3de5wcVZn/8c83Ny4JhEsGECUEEIxE5BYirCggCBJULoKwCHj7GUWFXXVBEFQuKuBldUVFATGACAKCbERFRG6C4ia4q4JcBMHbIuMi7rLCcsnz++M57VSamWRmunu6OvN9v179mq7q6npOd9fUc86pU1WKCMzMzOpmQrcLYGZmNhgnKDMzqyUnKDMzqyUnKDMzqyUnKDMzqyUnKDMzq6WOJihJ8yX9QtLdkj6wgmWPkfSLTpbHzMx6R8cSlKSpwFnAHsAcYG9J2w2x7EuBQztVFjMz6z2TOrjuecDtEfEQgKTLgfnA7dWFJM0APg28A/jycFY8Y8aMmDVrVlsLa2Zm3bFkyZI/RURf8/xOJqgNgYcr0/3A5tUFJAk4HzgW+ONwVzxr1iwWL17cjjKamVmXSXpwsPmdHiSxtGl6StP0e4BbI+KGFa1I0gJJiyUt7u/vb1f5zMyspjqZoB4CZlSm+8q8qk2AIyTdBVwHbC7p5sFWFhFnR8TciJjb1/eslqCZma1kOtnFdxvwZUnrAY8ABwInSpoOTI+I30TEUY2FJc0CvhURL+tgmWph1nFXdzzGA6fv0/EYZmad1LEEFRGPSToKuB6YDHw1Im6U9CbgTcCunYo9HE4SZmb11skWFBGxCFjUNG8hsHCQZR8AXtTJ8pjZ+OPKaO/qaIKyevI/rJn1Al/qyMzMasktKDPrqLFosUM9W+3urWiNW1BmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLTlBmZlZLHU1QkuZL+oWkuyV9YJDXV5X0fUn3SbpnsGXMzGx86liCkjQVOAvYA5gD7C1pu0EWPSMiNgO2Bg6WtE2nymRmZr2jky2oecDtEfFQRDwNXA7Mry4QEU9ExLXl+ePAr4D1O1gmMzPrEZ1MUBsCD1em+4ENhlpY0vrAjsBtQ7y+QNJiSYv7+/vbWlAzM6ufTg+SWNo0PWWwhSStAlwGnBARjw62TEScHRFzI2JuX19fe0tpZma108kE9RAwozLdV+YtQ9IU4BvAdyJiYQfLY2ZmPaSTCeo2YAdJ60maBBwIXCdpuqSZAJJWBxYBN0fEaR0si5mZ9ZiOJaiIeAw4CrgeuBO4NiJuBPYHLiiLzQN2Bd4s6a7ycKIyMzMmdXLlEbGIbCFV5y0EFpbnNwCrdLIMZmbWm3wlCTMzqyUnKDMzq6WOdvGZNZt13NUdj/HA6ft0PIaZdZ4TlNkYcXI2Gxl38ZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS35YrE2bvhirWa9xS0oMzOrJScoMzOrJScoMzOrpY4mKEnzJf1C0t2SPjDaZczMbPzpWIKSNBU4C9gDmAPsLWm7kS5jZmbjUydbUPOA2yPioYh4GrgcmD+KZczMbBzqZILaEHi4Mt0PbDCKZczMbBxSRHRmxdIbgJ0j4sgyfSiwa0QsGMkylWUXAAsAZs6cuf2DDz7YkXKbrYx8Dtj41Cu/u6QlETG3eX4nW1APATMq031l3kiXASAizo6IuRExt6+vr60FNTOz+ulkgroN2EHSepImAQcC10maLmnm8pbpYJnMzKxHdCxBRcRjwFHA9cCdwLURcSOwP3DBCpYxM7NxrqPX4ouIRcCipnkLgYXLW8bMzMxXkjAzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1pygjIzs1rqWIKSNFfSTyXdI+mzkgaNJelSSfeX5c6UpE6VyczMekcnW1AXAYdFxBZAH7DfEMtdCGwGvBB4PvDaDpbJzMx6REcSlKRNgL9GxB1l1iXA/MGWjYhFkZ4B7gQ26ESZzMyst3SqBbUh8HBlup8VJB5JqwP7AjcM8foCSYslLe7v729XOc3MrKYmtfJmSd8HZgzy0ruApU3zpixnPQLOAy6MiLsHWyYizgbOBpg7d26MqsBmZtYzWkpQEbHHYPMlbcayiasPeGiIZQV8CXg0Ik5upTxmZrby6EgXX0TcB0yXNLvMOgS4DrIrryQwJE0EFgJPAkd2oixmZtabOjmK7zDgEkn3Ao8AXy3z51GSFbARcDiwB/BLSXdJuqCDZTIzsx7RUhff8kTET4BtBpl/AzCrPH8AnyxsZmaDcHIwM7NacoIyM7NacoIyM7NacoIyM7NacoIyM7NaUkTvXZRh7ty5sXjx4m4Xw8zM2kDSkoiY2zzfLSgzM6slJygzM6slJygzM6slJygzM6ulnhwkIakfeLDb5TAzs7bYOCL6mmf2ZIIyM7OVn7v4zMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMyslpygzMysliZ1uwCjMWPGjJg1a1a3i2FmZm2wZMmSP0VEX/P8nkxQs2bNYvHixd0uhpmZtYGkBweb7y4+MzOrJScoMzOrJScoMzOrpbYcg5I0H/g4MBk4PyI+NsgyNwCzgCfKrK9GxEckrQtcBGwK3A8cGhGPtKNcZlWzjru64zEeOH2f2sY36zUtt6AkTQXOAvYA5gB7S9puiMUPjIjZ5fGRMu8TwJURsQVwJXBSq2UyM7Pe144uvnnA7RHxUEQ8DVwOzB/B+3cHvl6eXzLC95qZ2UqqHQlqQ+DhynQ/sMEgywVwuaS7JX1WUqN7cd2IeBQgIv4CrDNYEEkLJC2WtLi/v78NxTYzszpr1yCJpU3TUwZZZu+ImAVsCzwHWFDmxzDeS0ScHRFzI2JuX9+zzucyM7OVTDsS1EPAjMp0X5m3jIh4ovz9K7AIeGF56c+SpgFImg54gISZmbUlQd0G7CBpvdJtdyBwnaTpkmYCSFpV0q7l+WRgf+DH5f0/AA4uzw8BrmtDmczMrMe1nKAi4jHgKOB64E7g2oi4kUxCF5TFBJwi6dfAL4D7gIvLa8cAB0u6B3gdcGyrZTIzs97XlvOgImIR2W1XnbcQWFiePw68fIj39gN7tqMcZma28vCVJMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJacoMzMrJbacrFYMzOrn1nHXd3xGA+cvk/H1u0WlJmZ1ZITlJmZ1VJbuvgkzQc+DkwGzo+IjzW9virwLWAT4BlgYWMZSW8CPg38sSz+vxGxfTvKZWap17t6bHxquQUlaSpwFrAHMAfYW9J2gyx6RkRsBmxN3kF3m8prF0XE7PJwcjIzs7Z08c0Dbo+IhyLiaeByYH51gYh4IiKuLc8fB34FrN+G2GZmtpJqR4LaEHi4Mt0PbDDUwpLWB3YEbqvMPlTSvZKulbRlG8pkZmY9rl2DJJY2TU8ZbCFJqwCXASdExKNl9sXAuhGxOXAOsHCI9y6QtFjS4v7+/rYU2szM6qsdCeohYEZluq/MW4akKcA3gO9ExMLG/Ij4v4iIMnk5sPlgQSLi7IiYGxFz+/r62lBsMzOrs3YkqNuAHSStJ2kScCBwnaTpkmYCSFodWATcHBGnVd8s6eWSViuTrwMWt6FMZmbW41pOUBHxGHAUcD1wJ3BtRNwI7A9cUBabB+wKvFnSXeXRSFQvBX4p6S7gHcDbWy2TmZn1vracBxURi8gWUnXeQsrxpIi4AVhliPeeBpw22GtmZjZ++UoSZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS05QZmZWS77lu5lZh/g+XK1xC8rMzGrJCcrMzGrJCcrMzGrJx6DGIfeL23ji7b13uQVlZma15ARlZma15ARlZma11JZjUJLmAx8HJgPnR8THhruMpHWBi4BNgfuBQyPikXaUq67cJ25mtmItt6AkTQXOAvYA5gB7S9puBMt8ArgyIrYArgROarVMZmbW+9rRgpoH3B4RDwFIuhyYD9w+zGV2B95blrsEWAIc3YZyLZdbMWZjYyz+18D/byujdhyD2hB4uDLdD2wwgmXWjYhHASLiL8A6bSiTmZn1OEVEayuQ3gDsHBFHlulDgV0jYsFwlpH0PxGxRmXZxyJi2iBxFgALAGbOnLn9gw8+2FK5rTvccjWzZpKWRMTc5vntaEE9BMyoTPeVecNd5s+SppVCTgcGHSAREWdHxNyImNvX19eGYpuZWZ21I0HdBuwgaT1Jk4ADgeskTZc0c3nLlNd+ABxcnh9SmW9mZuNYywkqIh4DjgKuB+4Ero2IG4H9gQtWsAzAMcDBku4BXgcc22qZzMys97XlPKiIWAQsapq3EFi4vGXK/H5gz3aUw8zMVh6+koSZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdVSSwlK0lxJP5V0j6TPShp0fZIulXR/We5MSSrzd5X0mKS7Ko+1WimTmZmtHFptQV0EHBYRWwB9wH5DLHchsBnwQuD5wGsrr90QEbMrj0dbLJOZma0ERp2gJG0C/DUi7iizLgHmD7ZsRCyK9AxwJ7DBaOOamdn40EoLakPg4cp0PytIPJJWB/YFbqjM3kXSryTdImnn5bx3gaTFkhb39/e3UGwzM+sFk1a0gKTvAzMGeeldwNKmeVOWsx4B5wEXRsTdZfYtwPSIWCrppcDXJW0UEdH8/og4GzgbYO7cuc963czMVi4rTFARscdg8yVtxrKJqw94aIhlBXwJeDQiTq6s+6nK81skPQmsA/zXsEpvZmYrrVF38UXEfcB0SbPLrEOA6yC78koCQ9JEYCHwJHBkdR2SXtIYtSdpR+DJiHByMjOzFbegVuAw4BJJU4HvAV8t8+eRSWkWsBFwOHAP8MsywvwnEXEEOarva5KeAR4B3tBieczMbCXRUoKKiJ8A2wwy/wYyORERDzBESy0iFpKJzMzMbBm+koSZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdVSS/eDkjQXOAeYCnwX+MeIWDrIcguBVwL/U2ZdHxFHSloNOA/YHvgT8IaI+HUrZbJ6e+D0fbpdBDPrEa22oC4CDouILYA+YL/lLPsPETG7PBq3fj8GeKC8/2TgX1osj5mZrSRGnaAkbQL8NSLuKLMuAeaPcDW7l/cREdcA81TuCW9mZuNbKy2oDYGHK9P9wAZDLBvAZyTdK+lCSWsMsY7/BtYdbAWSFkhaLGlxf39/C8U2M7NesMIEJen7kv69+VFebj7eNGWI1RwZEc8DtgQeAT5YeW1Y64iIsyNibkTM7evrW1Gxzcysx61wkERE7DHYfEmbATMqs/qAh4ZYxxPl71OSvkEee6IsPwP4Y5lei2yJLdeSJUv+JOnBFS3XATPIwRzdMF5jdzv+eI3d7fjjNXa343cr9saDzRz1KL6IuE/SdEmzI+Iu4BByJB+SVgeeExH3lek9gWvLWw8CflyeX1fe90FJewF3RMRTw4jdlSaUpMURMdexx0/88Rq72/HHa+xux+/2Z2/W6ii+w4BLJN1Ldt19tcyfRyafhncADwB3AdOAT5f5HwdeUN5/EvC2FstjZmYriZbOg4qInwDbDDL/BmBWZfqAId7/V+D1rZTBzMxWTr6SxMic7djjLv54jd3t+OM1drfjd/uzL0MR0e0ymJmZPYtbUGZmVktOUGbWFZI2H8/xu6lXrtjjBDWIbv543YgtaW1Jm3azDN0iaeJ4jS9pG0kndmmbOwR4maTJYx272/ElrSbpYkmzuxB7DYDokWM7PgZVlB3F3wOXRcT/SdowIv6wsscu8V9OnhpwL3nV+U+Nt6vKS9o9Iq5b8ZJti6fGTkLSFGBWRNwzVvFL3E2B/yKvqbnC8w/bFLP6uacBL46IW8cidh3iV8qxJvDYYHd/6HDcT5Hnqy4F5kTEZ8cy/ki5BVVExDPktQRvlXQRcOpY1Sy7Ebup5v5z8hy0LwGPjGVyGusWRPP3Kuk15dJdJ0p6/ljFr+wk3wP8B3CEpKljEL96askfgdOASyWtNwaxq8lhZ3K7O0XSbp2O3e34jZZaZfv7f8Djkt48BrGr+/m7gKvJc1BrXwkd1wlqkJ3jg8Bs4ImIeGsnm8Hdit3YWEtSRNIGwFPAQuAG4IJOxB1GOeZL2qnTcSs7qAklIbwFOALYIyJ+NVbxSxkOAvYEXgZ8NCL+t1NxJW1V4j9dmT0b+CvwG/I76Ejcxk44IkLS9pLWBRYDrwGuAnYpLYqVMf4uJXajhTqt/L0HeA/wvqYE0s7Yjf+xpZX9zR+B24FvRsSiunfnj9sEVWpTjZ3ja8sB0x8BRwM7l/kTO/EDdjN2o0tB0naSlpA3jPxARJwG/Ao4RNJz2x23StKESjnWlvRd4ATgAkkHlvlt++yNVkNjnZJeC7wdmAjsRn7nx0s6V9LpbYzbiDehMm9NSYdKWr/EXw3YFlgg6VOSdm1+T4tlmCDp9eTnW1vSqyVdJelY4O6I+Cfg28C2krZuR8wmc4EdJB0i6SqylX4tMDcifgHcAaxDJupO6Fr80nV7uqS3S1q3bOfnS9of+H5EfAG4j2zFtl3lf+yNwO2SPkJWhF8NvFnSZnU/FjVuE1SpTe0g6UrgA+SG++qI+DLwJ0nHRcQznfgBxzp2Y2dXkt4USV8CjgJOIS9Dta2kE4EvAnOAbSRtIukl7YhfKUeje2uppA0lfZ5MFD+IiJcCxwEnSFqtHZ9d0vNLMny6xI3S1dIH7Ej2wx8LbEFequtm4NWN1kYbTClxq8cZnkseb3wZcD15i5n9gDXIK7t8YZD3jEqlIvBLcse0EFhAnoy5G1l73wj4N7JG/4ZWY5a41W7Eb5IXgD4cuKlc5+0C4I3KQQI/JLua5kka9IKhPRh/IkBEPAmcSLaUziW//2+Q9807qix+AnCQpFltiq3K81mSvg3sQFZ+/0rubyaT9+E7qSy3XTtid8K4SVDNXWqS/o7cWK6NiB2BfyavC/gq4EjymMRLJX1Z0ot6MXY1IZS/z5R/mg2AtSLiqoj4DdnN9UbgUeB75DUW7yKTVcsqXQ2N7rUjgM+SLYityYQ4ISK+Qd4f7L3V8o8y5m7kjmizMn2tpNeVrpabgd+Sd3k+OyL+sdRmf1Dmt3xcTNLnyO4jJG0qaaGkdSPil2QNfhdgakS8NiLeFREfIY8NfEctjiwb5Hf/OfATYE3gixFxNbmjWg3YJiIeIbt3Z5RtsNW4T5fpTSPiz8C3gMeBP5dFPwesAuxQtsdbyX3RK0cbuw7xGyq9IxPLwJsfARMj4hLgUnK73ErSRqUVdwXwiVZiVv/HKq3vCcBOwHURcSPZW3IbWRE5BXiupB8A10jaopX4nTJuElRlo9m41LB+SdaeNiyL3ETWpOZExM/I2sXxwJ/KRtRzsSsJ4S2SFkk6SdKW5AHarSW9oCz3n+Q/6RbA+eTtUJ4XEeeNNnaDJFW6GnaR9PdkbfKqiHgHcA5Zw21cr/FY4J8kbTKaVlTlH/V64G7g4PLSpZSulMjRcjcDs0pFYFNJN5GJ4/yI+PfRfdplau/HAdtL2gb4AyCytQpwIbmD3L3Ucl+r7G49FbgoRjmirlJzb/zux0k6TdLfRcSV5M7p5ZImR8RPyVZbo/Z8BzloYBeNsHtRaUIl7naS7gPOlvSpiPg3cvvaRHn3g6fJOxrsVsp7G3nrnXUa6+vF+JXpfSUtIpMAwBnAppK2Lr/tn8nWcqMi9GFg81Za7pX/sVOBj0qaHxH3Ax8iK71ExEPA/wFrR94C6Y3AyRHRF2M8gnS4xk2CKhvNA8CngMvJ7pdzgDmSXhwR/w08Talxk62aAyLi/T0eex/grSX2UuBk8r5bZ1F22MrjHs8DHoyIpRHxu4joVxuOg5Ua3YsknVFiXw58jazZQY5gu5vcca4fEf9B1iZH1YppHBCWtBb5+V4paYeIOAd4TFLjO/03skVxBNn99bGImF1quaMWEU9LmhYRjwGfBM4uO4OFwE7l9/4zWas+mLyo8n0l/ksi4vaRxlQeZ6oe13yOpHeSO+DfA1eW7+MKcie8a3nr74C/lHL/idwGRjT0ubQSonzvmykHJOxFdim9HnhxaTFfBEwHtlPeS25fBm7PsyZwaCnbiM7RqUH8CZX460maB7yT7EbdS9LR5PZ9EZmIIO8wvg7ZvQt5I9ffVKZHTNJUSeeR29MvgGMlvY38fwtJjYrac8l9DRHx29Kyau4WrY+IWOkf5A75KmDHMv0V4P3kldhPAM4kWw83Ae9oeu8EyvlidY4NTBhi/heAt5bn08nW02fIGv0vyO6PW4Ej2vRdT2qankjeeuX6yryNyBbji8v0XLL74f+NMuaE8ldk//oxZHIQ2Rr9Unl9HvA/ZBfngcB3yB3Z5BY/syrPNwauAV5Upu8H/r48/wjZQqKU8Xbg5W3czjckk9DNZEt4epm/ELikPP8Hcqd1Wfn9X1S+p4PI8+B2GUXcKcC7ycrGdSX+5uW1PcvnXJVMAj8Efgq8v/L+fYGjWvjc3Y4/CTidrOh8i+w6huwy/C6ZgNYhRw5+r5Tn7WWZaWTr9YQWf/v1y//xxDL9GrLl9mLyGOevyONxNzW2zV54dL0Abf0wlR3VID/eImDrMj2H7PKZDWxVfti7gYN7LTZNiakRv1KeBcAVlddfw8AO++CyU5rShu9+w6bpVzGwk96jxFmr8vop5FDXxg5m2+pnaf4emz8j8BzgM5V5c4BNy/O9yWNcryo7gB8A+5bXTi07jSXkSK7Rft55wDsr01tWvvPzgNPK81cDvy/P+4DvA3eSrcjnthB/ctPvfAp5XPON5Xe9Ati/8v0+TFYEZgIXA0c3rW+dEcSe2DR9LvCr8nyNsv4DgFXLvK8wUCk6FFhzsG22F+Lz7ArYy4CvkxWijciKxzeBVcrrXwA+RlacDi3T05vWscowYw9aCS2vrV22u/mV7+F7lAoQOSjiqtFub916dL0AHflQsEb529hZb1Q2jD0r/9jfImvRE8g+2q9X3j+xhdjTqxtTJ2Oz7A79QHIU3jSWrdHPIhPiu8r0PwCfr7z+c+B9LXzeXSmtBLImuRVZI7ySPDD/NjJJ/zNwZtN7f09pWVbmjWRncS8DrZMzyIPBlB3R+8q8NchBH/8K9JXX+9qwjc0jb8K5PrApuVM8rLy2OTlCb9cyfS3wL+X5esDsFuI2f1+NHeEnGEiEE8hW+inA88u8DwF3leeTK++fNMy4G5At/rXL9PbkIAPI7tpfAxuX6SOBzzNQKXsRmSSqcSeO8Lfudvy/o5LYgPXK3xeTLbfGdjiL7L7/x8q28B/kYBRGE795OWDd6nrK32nl+/kIsH6Z93VKi5g81vg7YGar2/5YPrpegJY/wLNbEJ+gUrOtzD+aHM79dmB3sqm7RXltC7L2+aoWY58AXDwWsSvr3oZMBneSgw1WH2SZl5HJ4ts0tRzIlsuOo4ld3v9echjt6mX6KPK8KsiW02lkrf75Jfa2lfc+p8Xf/itkgl2NrEH+ENivvLYdOVrq8DL9r8BL2rjdrQbcAnykTL+L7K5t7Bw+CFxans8mB0o867cZYcwXAjeSQ+RfRHYlfgnYsrz+QOXz70RWCt5eef+W1W2XYewgGajkbUsetzyeHAXXGBn4zvLdn0oOMAGYSnYrvp+m1sooPnNX41fKcRVweXl+KTnI4p/I45jvJSuhq5OVo33Kb9OoHMxuWteQLaEVlGE3coDV5cCpzesr29knyR6CfycT1BqV5d5ItuJHfchirB9dL0CbNp5ZjQ2RHC67UeW1xgY+lewTPq/8gPtUlpkIzBhl7OdVnu9T/ikmjFHsCeRxlH8s38GZZf6kyjKNMqxJUy2uTd/9p8huyv8ka5MnAp+uvP4+4JTy/ONUWostxNyW7Mf/QtlRnFrmvwm4ubLcIrJro482dGNW1vtWcgf5eeBnZG3+eWQ30rvLMpuSAxAaCXJUx7nI7rlG0ptMjgT8IbnD3I/sPjqHbLm+mhzo0njvsWSiXJumrt9hxp4JvLKxTQGHkJWhL5R5O5NJ+Q1kT8FtwG7ltX2B1zRvryP87N2Ov0nl+dSyjX+LPI67A1kZPqf8Ltc14pXt7Qxg9xa2scbvNZHsBbiIrIy8kqzs3cJAK22Z/3eyAjPqSmedHl0vQMsfIP+Bf0juJN9G1pw2WM7yqzdNtzIAYhpZM34LOQBhH+DKMYrdaNpPKn+3IGttU1YUgxa6MCvraCThD5M1933L9MFk19L2ZXovBgYGrEY5LjDSz9k0792UJEgmgvsaO5OyHVxItpguA7Zq4TNqsJ1a2VnsWZ4fDVxdnh9IHmM6rsT+Ei0cZyrr3Bb4XHl+BNml+rcadNkZLgBOKtO3AWeU58M+rjRE7I3IrsuPka3VfclKxhcryxzNQCvyOODHrW5bdYhPDqr4Cnls8U1ki/SNwO8qy6xNVjjnkMeXvkvZ9zDMrtNB4la77auJ58fAWZXp7ciu9FUq8zryv97NR08PMy9DPJ8EXk52Lb2A/Cc+uAwl/dtylbc9XuYtc87IKGM/VuK9gBxWugSYqqHPSG9L7PLeZ8rfxrXV9iRbD09K2l3lApiDxWi8txUxcBLoyeSxr+2U1/W7lTzX4p+Vly06lbwIriLi8Yh4YiTn2UTEM5LWkLSPBs62XxN4UNIqked6XAN8tLx2ENmq+W5EHBR5kupoP2NEDh/eWNILJU1WXgZqfeDG8jt+BZimPAn4cjIpzQO+GhFvj4jfjzZ+KcNPgd0k9ZPduXeQXcLblWH5/cBj5LEOyB32jPL8z9DSZZMmki2FN5PHLa8iE/Azkl5dlrmFvG3FRLIF+ZYSsx2XqupK/PK//QR5dZHFZIvpqYg4H3hK0uFl0cfJK3BsFBFfI3+bxv/F06MpQwycz3QM8D1J/6Q8cftIYA9Jjd/2brIXYdPKezvyv95V3c6Q7XyQTd9/JbuVfkaOZGppCPEw404ha9VXk625dduwzuaRSoO2thhoyexHthwuJf9Rtm/TZ5s4VPxK7M3L5z+I7HacSO4o/gU4dITx1PR3P3IwxHnlc+1Fdml+ktK9SrYel1K6d9r4u4o86HwXOWz7MrI75ybgLZXlTiKH8Y6q1ryCMmxCdufdW5k3k9wZN471vaZ8P6Pe1hl6FOpbgK8Ce5fp51S+/01L3DOq2+tQ22ovxG/67d9MJqADKvNfw8BglFXJwTDzWvyNq62m9Rjomt6KPM723vLaOZQBTuV/7Vu0seu6jo+uF2AFP9ywdtKV12eS19uC3Gnu1OnYlR3p6uRosceBnYdT3iHWV91YJ5P97iscdUYOq17KIANERvn5qyMBJ1BGTw31uchjI58DtlvR+obz2SvzPkdJcmQX2tfIYz5fI48BHEkOhvgKleOBo/neB9k5Ns4raozYOo887jWbvCTSS8mBLxeS3ZqrjOY3H2x7G+T1Mxk4xiiy1+AmsrvvTgaOf2g461tOnMYI2EmVWIeTrbapZd5OZLL+NTkIpm3dSAyMgp08FvGbt7lBtoFXkqPwplfmXV++8+vJlruGWt9wY5Ot8s3KdvgKcn/yUXKk68Vlm1+H7M6+iqwIv2a4sXr10fUCDOOHG8lOegGVftqxit20gR5L0wm3oyzH/uTVBn5EtswGPZZCqUGVneM6lflt2WmQo9P+jRwQcCBNtfTKDnEtMmns0jR/RImJ7C49nIGRaeeSF9dstOSuKL/zumTXy3eA17bw+dT0++1EXh9wctk5XdG0/G/ILrQ3kF2bN1NOOB5l/OaK0LOGEJfnW5YdZeNY247kKLKPNv8mo9nWy/RQI2A3Jo/tfogcbv2ushPdcKh1jTL+UKNgOx6fIU7TKK9dDXyoPN+cPO53GZXBWC38/pPIVvp/kq3ixqkQR5FXF2n8Lh8v2+rbgP9oNW6vPLpegBX8eMPdSTdqe9OonAw6RrGXqXmTNflhXxGhbHTVHdFEcpTYHyjDwcnjGsdTGfxB0wH8slOd2XitTd/By8nWwZrkgepbaOo6LOVoJMlpI1z/hKb1vJJsmSwk+9inkTXk91X+cQ+nHBRvw+erxl+N7Kp7iEy0p5Sdxx+BF1aWqw7rbluXHkMPIa5uWx8iRw/+nLzYa/UA+WhbTLMYYgRs03Jbk0Pc/51Kl1bz9j+K+EOOgh2j+NswxGkaDFSKtiRbS42rvk9rR3xyZOAlZOt47/K/tg95yOAWytVdyOH11zNw4vvvaeGiAr306HoByhfe9p10F2JvQw4HfVl1h7aC2NW4MxjoStqqbKAHlOmdyG6sVzX/85LdUF8jBye09RImZEvl4+SO8Q7gwGq5WXaU0fpkQhtxbZ5sCV1SYm1V5p0PfJkcKXUxeTzraPJ41B5t/pxHk4M5Plym55BXA5hbtoVbyRr7yWTXSquj4xrHW5Y3hPg9zdtImT4IeMVg6xtFOYY1ApaB1nDLJzg3rXdYo2A7GH84p2k0fqtZlBOvK6+11EtBXhfvR5Xp48v/wMZk1/WNZAv9CpY9h+0V1emV+dH9AnRxJ93G2BeTw0CXG7vyj7Z/NT7ZtfEgWZM7o5TlTeROu7HMiWRNarPK+k4ia34f7tBvsw/ZovjnyrwtqJxsWynbfc3zh7H+HclujYXkcPUfAIeU11YB/lR+i7XIY1xfpMUD0k3xX1W+84Xk6LCvkzut1cid5sVluUPKd38+TZd0amFbb8cQ4lElpup7y+fdnhx0sJS80shmy4tBG7qPK/H3KNv818mrRXyPckWI4XyPrf4WrPg0jcE+f1tazmSCPp+Bc72eQybMI8jKwwEsO0Bj1L93rz7GPmAXd9LdjF2WX5WsMS9l4EKpLykb5SSyb/tScvTQi8mh641LFG1CnjW/KnkuzB1k0hz1DnMY5W2MFvtgmT68xG1cYuYgcmj9P6zon5bBd7AfJW9x35g+nmytNc7Afz/wnx36bM8jk1IjCc0u041W80Zkpee4Mt220aDk9dp+QB5Dmkye63QvA92YU8nunmG1xNtUpq6MgC2x2z4KdhRleDdwYnm+O20eETpEzInkidQfZmBQyCKywrRG87Jj/Z3U4TH2Abu4k+5y7FOBg8rzEylNe/Js+G8yMELpALJWNY08cHsLTV0bZKvipWP0e80muxm+Tdb0G7W9G8kuuLVW8P7l1kDJY077leeNy/NUh3C/e6j1DLP8Q11Mt3FlgusYSAynkaMG1yC7cPdofN5Rxm7uBl7eEOJzaeMQYro4AnYk8Su/R1tGwY4ifkdP0xhGOWeRI0OvIY8tfoI81rV1q9/ByvAY22Bd3El3KzYDNaO+slNsXLbm1+RAjM3Illn1+ng/Lxvu2pQurco/8pg388mkPLNp3oiGdJPJ4ExgtTLdaJm+Afh1Zbn3kUlis9GUtbKerVn2OmTPSjRkl8qnyZu2QQ7j/Smlhd1i/Gp33pgNIWbZhDimI2BHGx/aNwq2hc/f1tM0RljmVcq+YAuye/mrtHBB4ZXpMVY/QNd20t2KPdhy5HDSc8vz/YH7y/NTyHNsdieHl15BSZh1e7CCrgaePWx7M7IL9XKGOEZFjpRsXLpnJis4BrGi35uBSsfLyrxDgC83l7+UdReya6vRbbkX5VhkG76r5iHEjWOcHR9CTBdHwI4wfkujYNsQv6OnaYygvFPKNnIXcORYxq7zo9Nfetd20nVJEOQ1ur5NjtDaqOwMX1Ve+yFwTHn+ZvJA8eWUYzC99mja+Te6Tg4kh4y/fqjlyW7WX9PCwefyD/4OSg247PRPILvrTqSMihvkfWuTxx1PavN3MSZDiOniCNg2x9+GEY6C7dTnp0vdamQX54iuVbmyP8bqi+/aTnosYzOww21c7ud4cmThHpQuK/LS/AvJpvxs4CkGatZrVdbVsyN2yEEAZzNwnO9s8kKezzroTmU0WQvxGut4N1kL3YIcKn4heYHRr1Bub1KWG/L+Om38Djo+hJgujoBtc/xhjYKt2+f3o/OP9q+wizvpbsVu+kep3hTtXDJBrlPKsDdZc7uEgduwn0nl9huj+dxd23ie3T2zLXkM54tkkrq87CwaJzoOehmkNpZnbTIJNCodjUT5O3Jwwonk+TbTyusdqynTgSHEdH8U6riO78fYP9q3oi7upLsZu+l97yB30KeSXRWvA/6bHO22EPgv8pL988lRWmuPJk4dHk3feaMffyeym1TkpWDuLjuMCWVn8EWabnfdQvxqYlyrsfMhTxY+q3z/jZN8LyFbJueS16/7wFh8P7R5CDFdPk1hvMf3Y+wf7V9hF3fSYxWbZw8EaJzk9xnyoPuHyG6DmWRNulFjfyvlACjLXkesJ4eSksdZvkR2oTWO/Uwo3/X7yBNOzyWvAL022dXatltOM3C78xlky+mTZfqD5PHG1YHXlzJuXl5ryx1Wh1m+WbRpCDFdPk1hvMf3ozuP0b+xizvpLseuHlhtrHcOmQh3b6ybPOZyPFm7fy15NeY7gDmjidvtB88+r2R6+c6PJ3fE/0UOGd8KuKOy3PfJCsKqzesYYfzmYwd/x7LHeLYlh2jvXLaHz5EVlElkkpg72tgtfm8tDSGmy6cpjPf4fnT3MaobmZUbekVEhKRpZfZksotnUUTcSNacf0butCYBr5D0DfIY0E0AEfGHxk29omw9dY5dll0qaZKkTwLfkHQYecO4D5PXdCMi/gA8AzRuJrglsDgi5kTEHZV1DTtut0jaBAa98dkGZCv0GvJK5z8hjzPdAawl6WRJNwP3kyPknhhkHcOJv6ekQ2PgRm4vKeW5NSd1ZFn0XnI48dsi4h7ynKLdyVbeURGxeKSx2yEi/q+U651k6/6WiLhrRe9r3GQwIp4qf/vJbtLGjRnfC3wqIu4jL3L6znKjyqPI76I/Iv4cET8p74/yd+lwyj3e41tNjDazkTv+T5I7qMPI0UnvAa6qLHNMeaxFaVG0I6t2OfYq5A75g+QJljeRFxFdn+xO2Kss91kGDtZXW3s9c8kSsgW6tDxfhxz0cCLZn78Z2Wr8EQNXghB5u4wXkFc/b/mKy+RVFe4guwuvJmvHnyePPWxLHudaqyy7K3kH1EPJFl7Lt0No43c5qiHEdPk0hfEe34/uPka70XRtJ93tBFF21OeXHebXyVZD49pxh5KX47+KvNbaFk3v7YkuPfIAf2Po9lfIIcBfII/rfJI8prM65QZ+lfd9gexmbecN7ES2iO8mb2s/hbxJ4GWVMnwOeCHZ1XMW5Z5Uvfagy6cpjPf4ftTvMaouPrLbZBpZoz2W7M66MCL+SCaPMyVdBbyI3FkTZauRpBhFV09NYkO2GjYgR2RdERG7RcSvJO1EdnndATwWEa+I7Gr6m0Y56kpFRDwT2ZU5jRx4sjnwYEScSCbnv5DDpd8LzJF0maSfkX3+J7fhO/6b8p19lvzNfxsRT5Lf/X3kjutY4EkyYT0aEUdGdvP2DEkTIbtRJU2OiKXlO9yMTL63A5tI2pu8NNOq5F2G7yJHRu5Q3v9oWd+EGEFX1niPbzU2mqxGdrFdQ9NZ7+RxoDXJ8xEu6kRG7WbsEmcC2Z34RQZGkX2GbGlMJQ/S/5Y237tmLB/kCMifAB8t0+8Bflb5/AcA51AGfJCtyY6e5EheyPVrlekvsuytOdboZPwx+t67eprCeI/vR/0eo3tTF3fSdUgQZDffZ8k7kP6cPM9mo8rrbyGPffVEl17TZ9udvGvpq1n27qL3UK6RRh6DOgM4YQzLtX5Jmi8lKyK30nT+Wq886PJpCuM9vh+982gMvRwxSeuQo2peDKxLdm0dExG/La+/hbyMy19itEFqGLupHBuT59X8vEz3fNeCpH3IC6ZeSSbZ55HH2aaSoyTXK8ttGhH3j3HZ3kF2+dwCXBIRZ41l/HaobiOSpkXEY5LmkINN9o+I6yRtSHahijym9nKy5TCbvKbhHeX9Gun2Pd7jW28ZdYL62wq6uJOuS4Iow9XV68kJMvGQyX8GeWXlGeS5J3tJ+jE5KOKCLpVtVXI03IWRw7d7kqRJwOnkOWMXktfkO4C8pfi+ZZljyuLnkF1fiojTHN/Gk0mtriAiHoTu7KS7GbupHAGsFDW5iLhf0pujDHSQtDOZFCB3IE90sWxPkCP6epakVcibMj4EfIA86L85OQLyQEl7RcQ15JDq30bEo5LOaLQUJE2MFgahjPf41ltaTlAN3dxJr0wJoiYmSXoFecHNrcnLCAH0bKulRqqjUN9PZRSqpMYo1F+S15z7HLR9FOp4j289ZLTDzG0lVrrPHiGH985tdOm5v78tun2awniPbz2kbS0oW7lExBJgSbfLsRJaCnyXvJbcNwEkfYa88sW7gU8BF0vqi7y8j+PbuOUWlNkYKsdJzydPLr5G0s/JFsWHIuJ/I+KH5HUdnyrHVh3fxq2WR/GZ2eh0exTqeI9v9ecEZdZl3R6FOt7jW305QZmZWS35GJSZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdWSE5SZmdXS/wdvNAWtB6pZawAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Show the weights of different features in the first two principal components\n",
+    "\n",
+    "pca_weights = pca.components_\n",
+    "fig, (ax1,ax2) = plt.subplots(2,1)\n",
+    "fig.tight_layout()\n",
+    "ax1.bar(scalar_cols,pca_weights[0])\n",
+    "ax1.set_xticks([])\n",
+    "ax2.bar(scalar_cols,pca_weights[1])\n",
+    "plt.xticks(rotation=30, ha='right')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "include_colab_link": true,
+   "name": "AIMS2022_Python_Basics.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/shell.nix
+++ b/shell.nix
@@ -50,16 +50,6 @@ let
      doCheck = false;
   };
 
-  # numpy = pypkgs.numpy.overridePythonAttrs (old: rec {
-  #   version = "1.22.3";
-  #   pname = "numpy";
-  #   src = pypkgs.fetchPypi {
-  #    inherit pname version;
-  #    extension = "zip";
-  #    hash = "sha256-28dgGjt0ctVZ3HuTOxi0tm+ap0UsEg6H37M9AgCMihg=";
-  #  };
-  # });
-
   matminer = pypkgs.buildPythonPackage rec {
     pname = "matminer";
     version = "0.6.5";
@@ -133,7 +123,7 @@ let
 
 in
   pkgs.mkShell rec {
-    pname = "snakemake-tutorial";
+    pname = "jarvis-notebooks";
     nativeBuildInputs = with pypkgs; [
       jupyter
       jupyter_extra
@@ -144,6 +134,8 @@ in
       plotly
       nbval
       pytest
+      black
+      pylint
     ];
     shellHook = ''
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,157 @@
+# Usage:
+#
+#     $ nix-shell --pure --argstr version 2022.1.10 --argstr tag 20.09
+#
+
+{
+  tag ? "22.05",
+  version ? "2022.7.17"
+}:
+let
+  pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${tag}.tar.gz") {};
+  pypkgs = pkgs.python3Packages;
+
+  nbqa = pypkgs.buildPythonPackage rec {
+    pname = "nbqa";
+    version = "1.3.1";
+
+    src = pypkgs.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-66fz00k8ZCmww/ladkBnsrAHdF9ykDcphVCmFle/7F4=";
+    };
+
+    propagatedBuildInputs = with pypkgs; [ ipython tomli tokenize-rt ];
+
+  };
+
+  dgl = pypkgs.buildPythonPackage rec {
+     pname = "dgl";
+     version = "0.9.0";
+     format = "wheel";
+
+     src = pypkgs.fetchPypi rec {
+       inherit pname version format;
+       sha256 = "sha256-k+BPwi8/H8NP7Fp/AliuUaXcxoTxGoM6gGNyFLxW9Jg=";
+       dist = "cp39";
+       python = "cp39";
+       abi = "cp39";
+       platform = "manylinux1_x86_64";
+     };
+
+     propagatedBuildInputs = with pypkgs; [
+       tqdm
+       numpy
+       networkx
+       psutil
+       scipy
+       requests
+     ];
+
+     doCheck = false;
+  };
+
+  # numpy = pypkgs.numpy.overridePythonAttrs (old: rec {
+  #   version = "1.22.3";
+  #   pname = "numpy";
+  #   src = pypkgs.fetchPypi {
+  #    inherit pname version;
+  #    extension = "zip";
+  #    hash = "sha256-28dgGjt0ctVZ3HuTOxi0tm+ap0UsEg6H37M9AgCMihg=";
+  #  };
+  # });
+
+  matminer = pypkgs.buildPythonPackage rec {
+    pname = "matminer";
+    version = "0.6.5";
+
+     src = pypkgs.fetchPypi {
+       inherit pname version;
+       sha256 = "sha256-RRGJZdaNzyMxAMig+aU5Txu6ELfW4oKJcjuut3HeaqE=";
+     };
+
+     nativeBuildInputs = with pypkgs; [
+       monty
+       sympy
+       requests
+       future
+       plotly
+       numpy
+       scikit-learn
+       pymongo
+       jsonschema
+       pint
+       pymatgen
+     ];
+
+     propagatedBuildInputs = nativeBuildInputs;
+
+     postPatch = ''
+       rm requirements-optional.txt
+       touch requirements-optional.txt
+     '';
+
+     doCheck = false;
+  };
+
+  jarvisversion = version;
+  jarvistools =  pypkgs.buildPythonPackage rec {
+     pname = "jarvis-tools";
+     version = jarvisversion;
+
+     src = pypkgs.fetchPypi {
+       inherit pname version;
+       sha256 = "sha256-WmF3IBvM6Bje1TEIXWOjNV5Bw2bpkWJ3+ZI5k55lOCU=";
+     };
+
+     propagatedBuildInputs = with pypkgs; [
+       joblib
+       flask
+       numpy
+       phonopy
+       scipy
+       matplotlib
+       spglib
+       requests
+       toolz
+       pytest
+       bokeh
+       networkx
+       xmltodict
+       tqdm
+       pandas
+       pytorch
+       dgl
+     ];
+
+     doCheck = false;
+  };
+
+  nixes_src = builtins.fetchTarball "https://github.com/wd15/nixes/archive/9a757526887dfd56c6665290b902f93c422fd6b1.zip";
+  jupyter_extra = pypkgs.callPackage "${nixes_src}/jupyter/default.nix" {
+    jupyterlab=(if pkgs.stdenv.isDarwin then pypkgs.jupyter else pypkgs.jupyterlab);
+  };
+
+in
+  pkgs.mkShell rec {
+    pname = "snakemake-tutorial";
+    nativeBuildInputs = with pypkgs; [
+      jupyter
+      jupyter_extra
+      jarvistools
+      nbqa
+      pip
+      matminer
+      plotly
+      nbval
+      pytest
+    ];
+    shellHook = ''
+
+      SOURCE_DATE_EPOCH=$(date +%s)
+      export PYTHONUSERBASE=$PWD/.local
+      export USER_SITE=`python -c "import site; print(site.USER_SITE)"`
+      export PYTHONPATH=$PYTHONPATH:$USER_SITE
+      export PATH=$PATH:$PYTHONUSERBASE/bin
+
+    '';
+  }


### PR DESCRIPTION
This adds a single notebook (AIMS2022_Python_Basics.ipynb) to CI testing and linting using GitHub Actions. The environment is built with Nix, but Conda would be just the same. The notebook has been cleaned up somewhat to account for various issues. [Tests run in under 4 minutes](https://github.com/wd15/jarvis-tools-notebooks/actions).

This issue, https://github.com/usnistgov/jarvis/issues/251, was noticed in the notebook.

Need to switch on the github actions for this repository and then I'll reopen this PR to trigger them